### PR TITLE
WIP: Add decorator support when used from TypeScript

### DIFF
--- a/demo/ts/lit-element.html
+++ b/demo/ts/lit-element.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+--><html><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>lit-element demo</title>
+</head>
+<body>
+  <script type="module">
+    import { MyElement } from "./my-element.js"
+  </script>
+  <my-element bar="5" whales="5">Hi</my-element>
+</body></html>

--- a/demo/ts/my-element.ts
+++ b/demo/ts/my-element.ts
@@ -1,0 +1,58 @@
+// @ts-check
+import { LitElement, html } from '../../lit-element.js';
+import { customElement, property } from '../../lit-element-decorators.js'
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "my-element": MyElement;
+  }
+}
+
+@customElement('my-element')
+export class MyElement extends LitElement {
+  @property(String) foo: string = 'foo';
+  @property({ type: Number }) bar: number;
+  @property(Number) whales: number = 0;
+  @property({ type: Array }) friends: any;
+
+  constructor() {
+    super();
+  }
+
+  ready() {
+    this.addEventListener('click', async () => {
+      this.whales++;
+      await this.nextRendered;
+      this.dispatchEvent(new CustomEvent('whales', {detail: {whales: this.whales}}))
+      console.log(this.shadowRoot.querySelector('.count').textContent);
+    });
+    super.ready();
+  }
+
+  // @ts-ignore
+  render({foo, bar, whales}) {
+    return html`
+      <style>
+        :host {
+          display: block;
+        }
+
+        .count {
+          color: green;
+        }
+
+        .content {
+          border: 1px solid black;
+          padding: 8px;
+        }
+      </style>
+      <h4>Foo: ${foo}, Bar: ${bar}</h4>
+      <div class="content">
+        <slot></slot>
+      </div>
+      <div class="count">
+        whales: ${'🐳'.repeat(whales)}
+      </div>
+    `;
+  }
+}

--- a/demo/ts/tsconfig.json
+++ b/demo/ts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es2015",
+    "lib": ["es2017", "dom"],
+    "declaration": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "experimentalDecorators": true,
+    "outDir": "./"
+  },
+  "include": [
+    "./*.ts"
+  ],
+  "exclude": [
+    ""
+  ]
+}

--- a/src/@polymer/lit-element-decorators.ts
+++ b/src/@polymer/lit-element-decorators.ts
@@ -1,0 +1,25 @@
+export type LitElementPropertyType = BooleanConstructor|DateConstructor|NumberConstructor|StringConstructor|ArrayConstructor|ObjectConstructor;
+
+export interface PropertyOptions {
+  type: LitElementPropertyType;
+}
+
+export const customElement = (tagname: keyof HTMLElementTagNameMap) => {
+  return <T extends { new (...args: any[]): HTMLElement }>(clazz: T) => {
+    window.customElements.define(tagname, clazz);
+    return clazz;
+  };
+}
+
+export const property = (options: PropertyOptions | LitElementPropertyType) => {
+  return (prototype: any, propertyName: string): any => {
+    createProperty(prototype, propertyName, options);
+  };
+}
+
+function createProperty(prototype: any, propertyName: string, options: PropertyOptions | LitElementPropertyType): void {
+  if (!prototype.constructor.hasOwnProperty('properties')) {
+    Object.defineProperty(prototype.constructor, 'properties', { value: {} });
+  }
+  prototype.constructor.properties[propertyName] = options;
+}


### PR DESCRIPTION
- Add TypeScript example in demo/ which uses decorators
- Add decorator for customElements.define and adding properties

Missing:
- Documentation
- Tests (the current tests don't run locally for me yet)

I would like initial feedback on the approach, especially about how the build system should work. I also created issues for problems that I ran into.