### PR TITLE
Make ts compilable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.js
 *.js.map
 *.d.ts
+!custom_typings/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 /node_modules
 /bower_components
-/test/lit*
-/lit-element.js
-/lit-element.d.ts
-/lit-element.js.map
-/test
+*.js
+*.js.map
+*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /lit-element.js
 /lit-element.d.ts
 /lit-element.js.map
+/test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es2017",
     "module": "es2015",
+    "moduleResolution": "node",
     "lib": ["es2017", "dom"],
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
it seems as if it wont compile correctly if you have `"modules": "not commonjs"`, so you have to specify to resolve modules with `"moduleResolution": "commonjs"` to make it compile yet output es2015 modules