### PR TITLE
Export svg template literal from lit-extended

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -28,7 +28,7 @@ export {
 export {
   PropertiesMixinConstructor
 } from '@polymer/polymer/lib/mixins/properties-mixin.js';
-export {html} from 'lit-html/lib/lit-extended.js';
+export {html, svg} from 'lit-html/lib/lit-extended.js';
 
 // This is a hack to get tsc to not complain about unused interfaces and
 // still generate the type declarations properly


### PR DESCRIPTION
This also exports the `svg` template literal as defined in https://github.com/Polymer/lit-html/blob/1dc43255d172f412fd19784c190764d05605cc16/src/lib/lit-extended.ts#L25-L29

Fixes #56