### PR TITLE
Assign HTMLElementWithProperties as constant

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -88,8 +88,8 @@ export function styleString(styleInfo: {[name: string]: any}) {
   return o.join('; ');
 }
 
-export class LitElement extends PropertiesMixin
-(HTMLElement) {
+const HTMLElementWithProperties = PropertiesMixin(HTMLElement);
+export class LitElement extends HTMLElementWithProperties {
 
   private __renderComplete: Promise<any>|null = null;
   private __resolveRenderComplete: Function|null = null;


### PR DESCRIPTION
When using the closure compiler on a compiled version of LitElement, it is complaining that `The class in an extends clause must be a qualified name`. I believe the issue is that `class LitElement extends PropertiesMixin(HTMLElement)` attempts to extend the result of a function rather than a defined symbol. I think this change might fix that issue.

Please let me know if you think there is a different way to solve this, or if my code requires changes of any kind.

Thanks!