### PR TITLE
Fix webcomponents-bundle.js path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ current properties (props) to return a `lit-html` template result to render
 into the element. This is the only method that must be implemented by subclasses.
 
 ```html
-  <script src="node_modules/@webcomponents/webcomponents-bundle.js"></script>
+  <script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
   <script type="module">
     import {LitElement, html} from '@polymer/lit-element';
 


### PR DESCRIPTION
Hi everyone,

The path is incorrect since the package name is `@webcomponents/webcomponentsjs`.

Cheers,
Dominik