### PR TITLE
Fix TSLint by adding configuration and fix style errors

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -40,13 +40,13 @@ export type __unused = PropertiesChangedConstructor&PropertiesMixinConstructor;
  * @param element Element on which to set attributes.
  * @param attrInfo Object describing attributes.
  */
-export function renderAttributes(element: HTMLElement,
-                                 attrInfo: {[name: string]: any}) {
+export function renderAttributes(
+    element: HTMLElement, attrInfo: {[name: string]: string|boolean|number}) {
   for (const a in attrInfo) {
     const v = attrInfo[a] === true ? '' : attrInfo[a];
     if (v || v === '' || v === 0) {
       if (element.getAttribute(a) !== v) {
-        element.setAttribute(a, v);
+        element.setAttribute(a, String(v));
       }
     } else if (element.hasAttribute(a)) {
       element.removeAttribute(a);
@@ -60,7 +60,8 @@ export function renderAttributes(element: HTMLElement,
  * class names if the property value is truthy.
  * @param classInfo
  */
-export function classString(classInfo: {[name: string]: any}) {
+export function classString(
+    classInfo: {[name: string]: string|boolean|number}) {
   const o = [];
   for (const name in classInfo) {
     const v = classInfo[name];
@@ -77,7 +78,8 @@ export function classString(classInfo: {[name: string]: any}) {
  * property value. Properties are separated by a semi-colon.
  * @param styleInfo
  */
-export function styleString(styleInfo: {[name: string]: any}) {
+export function styleString(
+    styleInfo: {[name: string]: string|boolean|number}) {
   const o = [];
   for (const name in styleInfo) {
     const v = styleInfo[name];
@@ -91,7 +93,7 @@ export function styleString(styleInfo: {[name: string]: any}) {
 export class LitElement extends PropertiesMixin
 (HTMLElement) {
 
-  private __renderComplete: Promise<any>|null = null;
+  private __renderComplete: Promise<boolean>|null = null;
   private __resolveRenderComplete: Function|null = null;
   private __isInvalid: Boolean = false;
   private __isChanging: Boolean = false;
@@ -138,7 +140,7 @@ export class LitElement extends PropertiesMixin
    * @returns {boolean} Default implementation always returns true.
    */
   _shouldPropertiesChange(_props: object, _changedProps: object,
-                          _prevProps: object) {
+                          _prevProps: object): boolean {
     const shouldRender = this._shouldRender(_props, _changedProps, _prevProps);
     if (!shouldRender && this.__resolveRenderComplete) {
       this.__resolveRenderComplete(false);
@@ -157,7 +159,7 @@ export class LitElement extends PropertiesMixin
    * @returns {boolean} Default implementation always returns true.
    */
   protected _shouldRender(_props: object, _changedProps: object,
-                          _prevProps: object) {
+                          _prevProps: object): boolean {
     return true;
   }
 
@@ -194,6 +196,7 @@ export class LitElement extends PropertiesMixin
    * @param value {any}
    * @param old {any}
    */
+  // tslint:disable-next-line no-any
   _shouldPropertyChange(property: string, value: any, old: any) {
     const change = super._shouldPropertyChange(property, value, old);
     if (change && this.__isChanging) {
@@ -208,10 +211,10 @@ export class LitElement extends PropertiesMixin
   /**
    * Implement to describe the DOM which should be rendered in the element.
    * Ideally, the implementation is a pure function using only props to describe
-   * the element template. The implementation must return a `lit-html` TemplateResult.
-   * By default this template is rendered into the element's shadowRoot.
-   * This can be customized by implementing `_createRoot`. This method must be
-   * implemented.
+   * the element template. The implementation must return a `lit-html`
+   * TemplateResult. By default this template is rendered into the element's
+   * shadowRoot. This can be customized by implementing `_createRoot`. This
+   * method must be implemented.
    * @param {*} _props Current element properties
    * @returns {TemplateResult} Must return a lit-html TemplateResult.
    */
@@ -272,11 +275,10 @@ export class LitElement extends PropertiesMixin
   get renderComplete() {
     if (!this.__renderComplete) {
       this.__renderComplete = new Promise((resolve) => {
-        this.__resolveRenderComplete =
-            (value: boolean) => {
-              this.__resolveRenderComplete = this.__renderComplete = null;
-              resolve(value);
-            }
+        this.__resolveRenderComplete = (value: boolean) => {
+          this.__resolveRenderComplete = this.__renderComplete = null;
+          resolve(value);
+        };
       });
       if (!this.__isInvalid && this.__resolveRenderComplete) {
         Promise.resolve().then(() => this.__resolveRenderComplete!(false));

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -43,7 +43,7 @@ suite('LitElement', () => {
   test('renders initial content into shadowRoot', () => {
     const rendered = `hello world`;
     customElements.define('x-1', class extends LitElement {
-      _render() { return html`${rendered}` }
+      _render() { return html`${rendered}`; }
     });
     const el = document.createElement('x-1');
     container.appendChild(el);
@@ -56,7 +56,7 @@ suite('LitElement', () => {
   test('can set render target to light dom', () => {
     const rendered = `hello world`;
     customElements.define('x-1a', class extends LitElement {
-      _render() { return html`${rendered}` }
+      _render() { return html`${rendered}`; }
 
       _createRoot() { return this; }
     });
@@ -69,8 +69,8 @@ suite('LitElement', () => {
   test('renders when created via constructor', () => {
     const rendered = `hello world`;
     class E extends LitElement {
-      _render() { return html`${rendered}` }
-    };
+      _render() { return html`${rendered}`; }
+    }
     customElements.define('x-2', E);
     const el = new E();
     container.appendChild(el);
@@ -82,13 +82,11 @@ suite('LitElement', () => {
 
   test('renders changes when properties change', (done) => {
     class E extends LitElement {
-      static get properties() {
-        return { foo: String }
-      }
+      static get properties() { return {foo : String}; }
 
       foo = 'one';
 
-      _render(props: any) { return html`${props.foo}` }
+      _render(props: {foo: string}) { return html`${props.foo}`; }
     }
     customElements.define('x-3', E);
     const el = new E();
@@ -108,13 +106,11 @@ suite('LitElement', () => {
 
   test('renders changes when attributes change', (done) => {
     class E extends LitElement {
-      static get properties() {
-        return { foo: String }
-      }
+      static get properties() { return {foo : String}; }
 
       foo = 'one';
 
-      _render(props: any) { return html`${props.foo}` }
+      _render(props: {foo: string}) { return html`${props.foo}`; }
     }
     customElements.define('x-4', E);
     const el = new E();
@@ -135,9 +131,7 @@ suite('LitElement', () => {
   test('_firstRendered call after first render and not subsequent renders',
        async () => {
          class E extends LitElement {
-           static get properties() {
-             return { foo: String }
-           }
+           static get properties() { return {foo : String}; }
 
            foo = 'one';
            firstRenderedCount = 0;
@@ -149,7 +143,7 @@ suite('LitElement', () => {
                  stripExpressionDelimeters(this.shadowRoot!.innerHTML);
            }
 
-           _render(props: any) { return html`${props.foo}` }
+           _render(props: {foo: string}) { return html`${props.foo}`; }
          }
          customElements.define('x-5', E);
          const el = new E();
@@ -171,13 +165,11 @@ suite('LitElement', () => {
 
   test('User defined accessor can trigger rendering', async () => {
     class E extends LitElement {
-      __bar: any;
+      __bar?: number;
 
-      static get properties() {
-        return { foo: Number, bar: Number }
-      }
+      static get properties() { return {foo : Number, bar : Number}; }
 
-      info: any[] = [];
+      info: string[] = [];
       foo = 0;
 
       get bar() { return this._getProperty('bar'); }
@@ -187,9 +179,9 @@ suite('LitElement', () => {
         this._setProperty('bar', value);
       }
 
-      _render(props: any) {
+      _render(props: {foo: string, bar: number}) {
         this.info.push('render');
-        return html`${props.foo}${props.bar}`
+        return html`${props.foo}${props.bar}`;
       }
     }
     customElements.define('x-6', E);
@@ -218,9 +210,10 @@ suite('LitElement', () => {
          customElements.define('x-7', E);
          const el = new E();
          container.appendChild(el);
-         const d = el.shadowRoot!.querySelector('div')!;
+         const d = el.shadowRoot!.querySelector('div')! as (HTMLDivElement &
+                                                            {prop : string});
          assert.equal(d.getAttribute('attr'), 'attr');
-         assert.equal((d as any).prop, 'prop');
+         assert.equal(d.prop, 'prop');
          const e = new Event('zug');
          d.dispatchEvent(e);
          assert.equal(el._event, e);
@@ -228,13 +221,11 @@ suite('LitElement', () => {
 
   test('renderComplete waits until next rendering', async () => {
     class E extends LitElement {
-      static get properties() {
-        return { foo: Number }
-      }
+      static get properties() { return {foo : Number}; }
 
       foo = 0;
 
-      _render(props: any) { return html`${props.foo}` }
+      _render(props: {foo: string}) { return html`${props.foo}`; }
     }
     customElements.define('x-8', E);
     const el = new E();
@@ -258,9 +249,7 @@ suite('LitElement', () => {
 
   test('_shouldRender controls rendering', async () => {
     class E extends LitElement {
-      static get properties() {
-        return { foo: Number }
-      }
+      static get properties() { return {foo : Number}; }
 
       foo = 0;
       renderCount = 0;
@@ -296,9 +285,7 @@ suite('LitElement', () => {
 
            needsRender = true;
 
-           static get properties() {
-             return { foo: Number }
-           }
+           static get properties() { return {foo : Number}; }
 
            _shouldRender() { return this.needsRender; }
 
@@ -306,7 +293,7 @@ suite('LitElement', () => {
 
            foo = 0;
 
-           _render(props: any) { return html`${props.foo}` }
+           _render(props: {foo: string}) { return html`${props.foo}`; }
          }
          customElements.define('x-9.1', E);
          const el = new E();
@@ -343,9 +330,7 @@ suite('LitElement', () => {
       'render lifecycle order: _shouldRender, _render, _applyRender, _didRender',
       async () => {
         class E extends LitElement {
-          static get properties() {
-            return { foo: Number }
-          }
+          static get properties() { return {foo : Number}; }
 
           info: Array<string> = [];
 
@@ -377,16 +362,14 @@ suite('LitElement', () => {
 
   test('renderAttributes renders attributes on element', async () => {
     class E extends LitElement {
-      static get properties() {
-        return { foo: Number, bar: Boolean }
-      }
+      static get properties() { return {foo : Number, bar : Boolean}; }
 
       foo = 0;
       bar = true;
 
-      _render({foo, bar}: any) {
+      _render({foo, bar}: {foo: number, bar: boolean}) {
         renderAttributes(this, {foo, bar});
-        return html`${foo}${bar}`
+        return html`${foo}${bar}`;
       }
     }
     customElements.define('x-11', E);
@@ -404,14 +387,14 @@ suite('LitElement', () => {
   test('classString updates classes', async () => {
     class E extends LitElement {
       static get properties() {
-        return { foo: Number, bar: Boolean, baz: Boolean }
+        return {foo : Number, bar : Boolean, baz : Boolean};
       }
 
       foo = 0;
       bar = true;
       baz = false;
 
-      _render({foo, bar, baz}: any) {
+      _render({foo, bar, baz}: {foo: number, bar: boolean, baz: boolean}) {
         return html
         `<div class$="${classString({foo, bar, zonk : baz})}"></div>`;
       }
@@ -437,14 +420,20 @@ suite('LitElement', () => {
   test('styleString updates style', async () => {
     class E extends LitElement {
       static get properties() {
-        return { transitionDuration: Number, borderTop: Boolean, zug: Boolean }
+        return {
+          transitionDuration : Number,
+          borderTop : Boolean,
+          zug : Boolean
+        };
       }
 
       transitionDuration = `0ms`;
       borderTop = ``;
       zug = `0px`;
 
-      _render({transitionDuration, borderTop, zug}: any) {
+      _render(
+          {transitionDuration, borderTop, zug}:
+              {transitionDuration: number, borderTop: boolean, zug: boolean}) {
         return html`<div style$="${
             styleString(
                 {transitionDuration, borderTop, height : zug})}"></div>`;
@@ -484,7 +473,7 @@ suite('LitElement', () => {
 
       requestRender() { this._requestRender(); }
     }
-    const calls: any[] = [];
+    const calls: IArguments[] = [];
     const orig = console.trace;
     console.trace = function() { calls.push(arguments); };
     customElements.define('x-14', E);

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,61 @@
+{
+  "rules": {
+    "arrow-parens": true,
+    "class-name": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "no-any": true,
+    "prefer-const": true,
+    "no-duplicate-variable": true,
+    "no-eval": true,
+    "no-internal-module": true,
+    "no-trailing-whitespace": true,
+    "no-var-keyword": true,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-whitespace"
+    ],
+    "quotemark": [
+      true,
+      "single",
+      "avoid-escape"
+    ],
+    "semicolon": [
+      true,
+      "always"
+    ],
+    "trailing-comma": [
+      true,
+      "multiline"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "variable-name": [
+      true,
+      "ban-keywords"
+    ],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ]
+  }
+}


### PR DESCRIPTION
TSLint was actually never doing anything, because the `tslint.json` was missing. I adopted the configuration of Polymer/tools (https://github.com/Polymer/tools/blob/master/tslint.json) and fixed the corresponding issues. We were missing semicolons and `any` types. I also ran the formatter again, as some of the type definitions were getting quite long.