### PR TITLE
Add LitElementLight

### DIFF
--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -18,6 +18,7 @@ import {
   classString,
   html,
   LitElement,
+  LitElementLight,
   renderAttributes,
   styleString,
 } from '../lit-element.js';
@@ -51,19 +52,6 @@ suite('LitElement', () => {
     assert.equal(
         stripExpressionDelimeters((el.shadowRoot as ShadowRoot).innerHTML),
         rendered);
-  });
-
-  test('can set render target to light dom', () => {
-    const rendered = `hello world`;
-    customElements.define('x-1a', class extends LitElement {
-      _render() { return html`${rendered}`; }
-
-      _createRoot() { return this; }
-    });
-    const el = document.createElement('x-1a');
-    container.appendChild(el);
-    assert.notOk(el.shadowRoot);
-    assert.equal(stripExpressionDelimeters(el.innerHTML), rendered);
   });
 
   test('renders when created via constructor', () => {
@@ -211,7 +199,7 @@ suite('LitElement', () => {
          const el = new E();
          container.appendChild(el);
          const d = el.shadowRoot!.querySelector('div')! as (HTMLDivElement &
-                                                            {prop : string});
+                                                            {prop: string});
          assert.equal(d.getAttribute('attr'), 'attr');
          assert.equal(d.prop, 'prop');
          const e = new Event('zug');
@@ -485,5 +473,18 @@ suite('LitElement', () => {
     await el.renderComplete;
     assert.equal(calls.length, 4);
     console.trace = orig;
+  });
+
+  suite('LitElementLight', () => {
+    test('renders into to light dom', () => {
+      const rendered = `hello world`;
+      customElements.define('x-1a', class extends LitElementLight {
+        _render() { return html`${rendered}`; }
+      });
+      const el = document.createElement('x-1a');
+      container.appendChild(el);
+      assert.notOk(el.shadowRoot);
+      assert.equal(stripExpressionDelimeters(el.innerHTML), rendered);
+    });
   });
 });


### PR DESCRIPTION
Splits the LitElement class into an abstract LitElementBase class, which is implemented by LitElement (renders to shadow root) and LitElementLight (renders to light dom). See https://github.com/Polymer/lit-element/issues/42 for use cases for LitElementLight.

I'm not sure about the name 'LitElementLight', but I could not think of anything else.

I think this results in a clearer API than overriding methods. It clearly explains the intent to developers, and leaves the project flexible for different strategies in the future. For example when/if https://github.com/w3c/webcomponents/issues/468 becomes a thing, LitElementLight will have a use case within shared components as well.

Fixes https://github.com/Polymer/lit-element/issues/42