### PR TITLE
Changes properties change trace to warning

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -207,7 +207,7 @@ export class LitElement extends PropertiesMixin
   _shouldPropertyChange(property: string, value: any, old: any) {
     const change = super._shouldPropertyChange(property, value, old);
     if (change && this.__isChanging) {
-      console.trace(
+      console.warn(
           `Setting properties in response to other properties changing ` +
           `considered harmful. Setting '${property}' from ` +
           `'${this._getProperty(property)}' to '${value}'.`);

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -474,8 +474,8 @@ suite('LitElement', () => {
 
     }
     const calls: IArguments[] = [];
-    const orig = console.trace;
-    console.trace = function() { calls.push(arguments); };
+    const orig = console.warn;
+    console.warn = function() { calls.push(arguments); };
     customElements.define('x-14', E);
     const el = new E();
     container.appendChild(el);
@@ -484,6 +484,6 @@ suite('LitElement', () => {
     el.requestRender();
     await el.renderComplete;
     assert.equal(calls.length, 4);
-    console.trace = orig;
+    console.warn = orig;
   });
 });


### PR DESCRIPTION
LitElement warns when properties are changed as a result of property changes. That's all well and good, but the way it goes about it is disruptive. Instead of using the standard `console.warn`, LitElement logs a `console.trace`. This can be really annoying at times, as it fills up the console with  information which may not be immediately relevant. A console warning, which is in any event preferred for this type of message, will also print the trace, but collapsed behind a drill-down control, and should be used instead.

Example:
Developer has some improper data flow which causes this warning to log. However, it's not causing UX problems, so she's de-prioritized that for now. However, an important UI bug has come up and she needs to log information to the console to fix it. In this case, the log stack traces from `_shouldRender` are disruptive to her work.
<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
