### PR TITLE
move resolveRenderComplete check into promise

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -289,8 +289,8 @@ export class LitElement extends PropertiesMixin
       });
       if (!this.__isInvalid) {
         Promise.resolve().then(() => {
-          if(this.__resolveRenderComplete) {
-            this.__resolveRenderComplete!(false)
+          if (this.__resolveRenderComplete) {
+            this.__resolveRenderComplete!(false);
           }
         });
       }

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -287,8 +287,12 @@ export class LitElement extends PropertiesMixin
           resolve(value);
         };
       });
-      if (!this.__isInvalid && this.__resolveRenderComplete) {
-        Promise.resolve().then(() => this.__resolveRenderComplete!(false));
+      if (!this.__isInvalid) {
+        Promise.resolve().then(() => {
+          if(this.__resolveRenderComplete) {
+            this.__resolveRenderComplete!(false)
+          }
+        });
       }
     }
     return this.__renderComplete;


### PR DESCRIPTION
It could happen that __resolveRenderComplete is set to null (on Line 286) between the first if check and actually resolving the promise, which would lead to the following error when awaiting renderComplete:

`this.__resolveRenderComplete is not a function`

To solve this issue the check for resolveRenderComplete has been put inside the then-block. 

### Reference Issue
Fixes #130 
