### PR TITLE
Ensure that __isChanging gets set to false after errors

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -192,8 +192,11 @@ export class LitElement extends PropertiesMixin
   _flushProperties() {
     this.__isChanging = true;
     this.__isInvalid = false;
-    super._flushProperties();
-    this.__isChanging = false;
+    try {
+      super._flushProperties();
+    } finally {
+      this.__isChanging = false;
+    }
   }
 
   /**


### PR DESCRIPTION
This commit addresses #136

Wrapping the call to `super._flushProperties()` in a try{}finally{}
ensures that this.__isChanging gets set back to false even if an
error occurs within `super._flushProperties()`, which will avoid
distracting from the real error by logging reentrancy warnings.

I haven't been able to figure out how to write a good test for this.
If I throw an exception in the render function it fails the test
even thoug that's an expected behavior. As the render process
happens asynchronously, I can't trivially catch the error to avoid
failing the test.

<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
