### PR TITLE
Clarify `update()` signature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ into the element. This is the only method that must be implemented by subclasses
   By default, this method always returns true, but this can be customized as
   an optimization to avoid updating work when changes occur, which should not be rendered.
 
-  * `update()` (protected): This method calls `render()` and then uses `lit-html` in order to
+  * `update(changedProperties)` (protected): This method calls `render()` and then uses `lit-html` in order to
   render the template DOM. Implement to directly control rendered DOM.
   Typically this is not needed as `lit-html` can be used in the `render` method
   to set properties, attributes, and event listeners. However, it is sometimes useful


### PR DESCRIPTION
It is currently unclear where to manage non-rendering state change operations with the documentation deep in the explanation here rather than in the method signature.

In other places (i.e. render()), in text references to method calls seem to omit their arguments, so I did the same with update() and super.update(). Let me know if there is an alternate notation approach is preferred.