### PR TITLE
Update lifecycle based on feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,10 @@ into the element. This is the only method that must be implemented by subclasses
 
   * `updateComplete`: Returns a Promise that resolves when the element has completed
   updating that resolves to a boolean value that is `true` if the element completed the
-  update without triggering another update. This can happen if a property is set in
-  `update()` after the call to `super.update()` for example. This getter can be
-  implemented to await additional state. For example, it is sometimes useful to
-  await a rendered element before fulfilling this promise. To do this, first
-  await `super.updateComplete` then any subsequent state.
+  update without triggering another update. This happens if a property is set in
+  `updated()`. This getter can be implemented to await additional state.
+  For example, it is sometimes useful to await a rendered element before fulfilling
+  this promise. To do this, first await `super.updateComplete` then any subsequent state.
 
   * `requestUpdate(name?, oldValue?)`: Call to request the element to asynchronously
   update regardless of whether or not any property changes are pending. This should

--- a/README.md
+++ b/README.md
@@ -161,22 +161,20 @@ into the element. This is the only method that must be implemented by subclasses
   By default, this method always returns true, but this can be customized as
   an optimization to avoid updating work when changes occur, which should not be rendered.
 
-  * `update()` (protected): This method calls `render()` and then uses `lit-html` in order to
-  render the template DOM. Implement to directly control rendered DOM.
-  Typically this is not needed as `lit-html` can be used in the `render` method
-  to set properties, attributes, and event listeners. However, it is sometimes useful
-  for calling methods on rendered elements, for example focusing an input:
-  `this.shadowRoot.querySelector('input').focus()`. The `changedProperties` argument is a Map
-  with keys for the changed properties pointing to their previous values.
-  Note, calling `super.update()` is required. Before calling `super.update()`,
-  changes made to properties do not trigger `invalidate()`, after calling `super.update()`,
-  changes do trigger `invalidate()`.
+  * `update(changedProperties)` (protected): This method calls `render()` and then uses `lit-html`
+  in order to render the template DOM. It also updates any reflected attributes based on
+  property values. Setting properties inside this method will *not* trigger the element to update.
 
-  * `firstRendered()`: (protected) Called after the element's DOM has been
+  * `firstUpdated()`: (protected) Called after the element's DOM has been
   updated the first time. This method can be useful for capturing references to rendered static
-  nodes that must be directly acted upon, for example in `update()`.
+  nodes that must be directly acted upon, for example in `updated()`. Setting properties
+  inside this method will trigger the element to update.
 
-  * `updateComplete`:  Returns a Promise that resolves when the element has completed
+  * `updated(changedProperties)`: (protected) Called whenever the element's DOM has been
+  updated and rendered. Implement to perform post updating tasks via DOM APIs, for example,
+  focusing an element. Setting properties inside this method will trigger the element to update.
+
+  * `updateComplete`: Returns a Promise that resolves when the element has completed
   updating that resolves to a boolean value that is `true` if the element completed the
   update without triggering another update. This can happen if a property is set in
   `update()` after the call to `super.update()` for example. This getter can be
@@ -184,7 +182,7 @@ into the element. This is the only method that must be implemented by subclasses
   await a rendered element before fulfilling this promise. To do this, first
   await `super.updateComplete` then any subsequent state.
 
-  * `invalidate`: Call to request the element to asynchronously update regardless
+  * `invalidate()`: Call to request the element to asynchronously update regardless
   of whether or not any property changes are pending. This should only be called
   when an element should update based on some state not stored in properties,
   since setting properties automatically calls `invalidate`.
@@ -207,14 +205,15 @@ and the property's `shouldInvalidate(value, oldValue)` returns true.
 of the event loop, before the next paint).
 * `shouldUpdate(changedProperties)`: The update proceeds if this returns true, which
 it does by default.
-* `update(changedProperties)`: Updates the element. Setting properties inside
-update is handled specially. Before calling `super.update()`, setting properties
-will *not* trigger an update. After calling `super.update()` setting properties will
-trigger an update.
+* `update(changedProperties)`: Updates the element. Setting properties inside this
+method will *not* trigger the element to update.
   * `render()`: Returns a `lit-html` TemplateResult (e.g. <code>html\`Hello ${world}\`</code>)
-  to render element DOM. Setting properties in `render()` does not trigger an update.
-  * `firstRendered()`: Called after the DOM is rendered the first time.
-  Setting properties in `firstRendered()` does trigger an update.
+  to render element DOM. Setting properties inside this method will *not* trigger
+  the element to update.
+* `firstUpdated()`: Called after the element is updated the first time.
+  Setting properties inside this method will trigger the element to update.
+* `updated()`: Called whenever the element is updated. Setting properties inside
+this method will trigger the element to update.
 * `updateComplete` promise is resolved with a boolean that is `true` if the
 element is not pending another update, and any code awaiting the element's
 `updateComplete` promise runs and observes the element in the updated state.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and renders declaratively using `lit-html`.
   These properties can be declared in a few ways:
 
     * As class fields with the `@property()` [decorator](https://github.com/tc39/proposal-decorators#decorators),
-    if you're using a compiler that supports them, like [TypeScript](https://www.typescriptlang.org/) or [Babel](https://babeljs.io/).
+    if you're using a compiler that supports them, like [TypeScript](https://www.typescriptlang.org/) or [Babel](https://babeljs.io/docs/en/babel-plugin-proposal-decorators).
     * With a static `properties` getter.
     * By manually writing getters and setters. This can be useful if tasks should
     be performed when a property is set, for example validation. Call `requestUpdate(name, oldValue)`
@@ -155,37 +155,38 @@ into the element. This is the only method that must be implemented by subclasses
 
   * `shouldUpdate(changedProperties)` (protected): Implement to control if updating and rendering
   should occur when property values change or `requestUpdate()` is called. The `changedProperties`
-  argument is a map with keys for the changed properties pointing to their previous values.
-  By default, this method always returns true, but this can be customized as
+  argument is a Map with keys for the changed properties pointing to their previous values.
+  By default, this method always returns `true`, but this can be customized as
   an optimization to avoid updating work when changes occur, which should not be rendered.
 
   * `update(changedProperties)` (protected): This method calls `render()` and then uses `lit-html`
   in order to render the template DOM. It also updates any reflected attributes based on
   property values. Setting properties inside this method will *not* trigger another update..
 
-  * `firstUpdated()`: (protected) Called after the element's DOM has been
-  updated the first time. This method can be useful for capturing references to rendered static
-  nodes that must be directly acted upon, for example in `updated()`. Setting properties
-  inside this method will trigger the element to update.
+  * `firstUpdated(changedProperties)`: (protected) Called after the element's DOM has been
+  updated the first time, immediately before `updated()` is called.
+  This method can be useful for capturing references to rendered static nodes that
+  must be directly acted upon, for example in `updated()`.
+  Setting properties inside this method will trigger the element to update.
 
   * `updated(changedProperties)`: (protected) Called whenever the element's DOM has been
   updated and rendered. Implement to perform post updating tasks via DOM APIs, for example,
   focusing an element. Setting properties inside this method will trigger the element to update.
 
   * `updateComplete`: Returns a Promise that resolves when the element has completed
-  updating that resolves to a boolean value that is `true` if the element completed the
-  update without triggering another update. This happens if a property is set in
+  updating. The Promise value is a boolean that is `true` if the element completed the
+  update without triggering another update. This happens if a property is set inside
   `updated()`. This getter can be implemented to await additional state.
   For example, it is sometimes useful to await a rendered element before fulfilling
-  this promise. To do this, first await `super.updateComplete` then any subsequent state.
+  this Promise. To do this, first await `super.updateComplete` then any subsequent state.
 
   * `requestUpdate(name?, oldValue?)`: Call to request the element to asynchronously
   update regardless of whether or not any property changes are pending. This should
-  only be called when an element should update based on some state not triggered
-  by setting a property or when manually implementing a property setter. In this
-  case, pass the property `name` and `oldValue` to ensure that any configured
-  property options are honored. Returns the `updateComplete` promise which is
-  resolved when the update completes.
+  be called when an element should update based on some state not triggered
+  by setting a property. In this case, pass no arguments. It should also be called
+  when manually implementing a property setter. In this case, pass the property
+  `name` and `oldValue` to ensure that any configured property options are honored.
+  Returns the `updateComplete` Promise which is resolved when the update completes.
 
   * `createRenderRoot()` (protected): Implement to customize where the
   element's template is rendered by returning an element into which to
@@ -195,28 +196,29 @@ into the element. This is the only method that must be implemented by subclasses
 ## Advanced: Update Lifecycle
 
 * When the element is first connected or a property is set (e.g. `element.foo = 5`)
-and the property's `hasChanged(value, oldValue)` returns true.
-* `requestUpdate()`: Updates the element after waiting a [microtask](https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/) (at the end
+and the property's `hasChanged(value, oldValue)` returns `true`.
+* `requestUpdate()`: Updates the element after awaiting a [microtask](https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/) (at the end
 of the event loop, before the next paint).
-* `shouldUpdate(changedProperties)`: The update proceeds if this returns true, which
+* `shouldUpdate(changedProperties)`: The update proceeds if this returns `true`, which
 it does by default.
 * `update(changedProperties)`: Updates the element. Setting properties inside this
 method will *not* trigger the element to update.
   * `render()`: Returns a `lit-html` TemplateResult (e.g. <code>html\`Hello ${world}\`</code>)
   to render element DOM. Setting properties inside this method will *not* trigger
   the element to update.
-* `firstUpdated()`: Called after the element is updated the first time.
-  Setting properties inside this method will trigger the element to update.
-* `updated()`: Called whenever the element is updated. Setting properties inside
-this method will trigger the element to update.
-* `updateComplete` promise is resolved with a boolean that is `true` if the
+* `firstUpdated(changedProperties)`: Called after the element is updated the first time,
+immediately before `updated` is called. Setting properties inside this method will
+trigger the element to update.
+* `updated(changedProperties)`: Called whenever the element is updated.
+Setting properties inside this method will trigger the element to update.
+* `updateComplete` Promise is resolved with a boolean that is `true` if the
 element is not pending another update, and any code awaiting the element's
-`updateComplete` promise runs and observes the element in the updated state.
+`updateComplete` Promise runs and observes the element in the updated state.
 
 ## Bigger Example
 
 Note, this example uses decorators to create properties. Decorators are a proposed
-standard currently available in [TypeScript](https://www.typescriptlang.org/) or [Babel](https://babeljs.io/).
+standard currently available in [TypeScript](https://www.typescriptlang.org/) or [Babel](https://babeljs.io/docs/en/babel-plugin-proposal-decorators).
 
 ```ts
 import {LitElement, html, property} from '@polymer/lit-element';

--- a/README.md
+++ b/README.md
@@ -45,11 +45,9 @@ and renders declaratively using `lit-html`.
     attribute name determined according to the rules for the `attribute`
     propety option and the value of the property serialized using the rules from
     the `type` property option.
-    * `hasChanged`: Indicates if a property should be considered changed when it's set.
-    This function takes the `newValue` and `oldValue` and returns `true` if an
-    update should be requested. If not present, a strict identity check is used.
-    This is useful if a property should be considered dirty only if some condition
-    is met, like if a key of an object value changes.
+    * `hasChanged`: A function that indicates if a property should be considered
+    changed when it is set. The function should take the `newValue` and `oldValue`
+    and return `true` if an update should be requested.
 
   * **React to changes:** LitElement reacts to changes in properties and attributes by
   asynchronously rendering, ensuring changes are batched. This reduces overhead
@@ -163,7 +161,7 @@ into the element. This is the only method that must be implemented by subclasses
 
   * `update(changedProperties)` (protected): This method calls `render()` and then uses `lit-html`
   in order to render the template DOM. It also updates any reflected attributes based on
-  property values. Setting properties inside this method will *not* trigger the element to update.
+  property values. Setting properties inside this method will *not* trigger another update..
 
   * `firstUpdated()`: (protected) Called after the element's DOM has been
   updated the first time. This method can be useful for capturing references to rendered static

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -519,12 +519,11 @@ export abstract class UpdatingElement extends HTMLElement {
   /**
    * Returns a Promise that resolves when the element has completed updating
    * that resolves to a boolean value that is `true` if the element completed
-   * the update without triggering another update. This can happen if a property
-   * is set in `update()` after the call to `super.update()` for example.
-   * This getter can be implemented to await additional state. For example, it
-   * is sometimes useful to await a rendered element before fulfilling this
-   * promise. To do this, first await `super.updateComplete` then any subsequent
-   * state.
+   * the update without triggering another update. This happens if a property
+   * is set in `updated()`. This getter can be implemented to await additional
+   * state. For example, it is sometimes useful to await a rendered element before
+   * fulfilling this promise. To do this, first await `super.updateComplete`
+   * then any subsequent state.
    *
    * @returns {Promise} The promise returns a boolean that indicates if the
    * update resolved without triggering another update.
@@ -560,7 +559,7 @@ export abstract class UpdatingElement extends HTMLElement {
 
   /**
    Invoked whenever the element is updated. Implement to perform
-   post updating tasks via DOM APIs. For example, focusing an element.
+   post updating tasks via DOM APIs, for example, focusing an element.
    Setting properties inside this method will trigger the element to update.
    */
   protected updated(_changedProperties: PropertyValues) {}

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -21,7 +21,6 @@ export {html, svg} from 'lit-html/lit-html';
 
 export abstract class LitElement extends UpdatingElement {
 
-  private _firstRendered = false;
   /**
    * Render method used to render the lit-html TemplateResult to the element's DOM.
    * @param {TemplateResult} Template to render.
@@ -32,14 +31,9 @@ export abstract class LitElement extends UpdatingElement {
 
   /**
    * Updates the element. This method reflects property values to attributes
-   * and calls `render` to render DOM via lit-html. It should be overridden to
-   * perform tasks on rendered DOM. Within `update()` setting properties does
-   * not trigger `invalidate()`, allowing property values to be computed and
-   * validated before DOM is rendered and updated. This means in an override
-   * of `update()`, before calling `super.update()` setting properties will not
-   * trigger another update, but after calling `super.update()` setting
-   * properties will trigger another update.
-   * * @param changedProperties Map of changed properties with old values
+   * and calls `render` to render DOM via lit-html. Setting properties inside
+   * this method will *not* trigger the element to update.
+   * * @param _changedProperties Map of changed properties with old values
    */
   protected update(changedProperties: PropertyValues) {
     super.update(changedProperties);
@@ -48,28 +42,13 @@ export abstract class LitElement extends UpdatingElement {
     } else {
       throw new Error('render() not implemented');
     }
-    if (!this._firstRendered) {
-      this._firstRendered = true;
-      if (typeof this.firstRendered === 'function') {
-        this.firstRendered();
-      }
-    }
   }
 
   /**
    Invoked on each update to perform rendering tasks. This method must return a
-   lit-html TemplateResult. Setting properties in `render()` will not trigger
-   the element to update.
+   lit-html TemplateResult. Setting properties inside this method will *not*
+   trigger the element to update.
    * @returns {TemplateResult} Must return a lit-html TemplateResult.
    */
   protected abstract render(): TemplateResult;
-
-  /**
-   Invoked when the element's DOM is first rendered. Override to perform
-   post rendering tasks via DOM APIs. For example, focusing a rendered element.
-   Setting properties in `firstRendered()` will trigger the element to update.
-   * @returns {TemplateResult} Must return a lit-html TemplateResult.
-   */
-  protected firstRendered?(): void;
-
 }

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -32,7 +32,7 @@ export abstract class LitElement extends UpdatingElement {
   /**
    * Updates the element. This method reflects property values to attributes
    * and calls `render` to render DOM via lit-html. Setting properties inside
-   * this method will *not* trigger the element to update.
+   * this method will *not* trigger another update.
    * * @param _changedProperties Map of changed properties with old values
    */
   protected update(changedProperties: PropertyValues) {

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -132,7 +132,7 @@ suite('Styling', () => {
         <x-inner></x-inner>`;
       }
 
-      firstRendered() {
+      firstUpdated() {
         this.inner = this.shadowRoot!.querySelector('x-inner')! as LitElement;
       }
     }
@@ -173,7 +173,7 @@ suite('Styling', () => {
         <x-inner1></x-inner1>`;
       }
 
-      firstRendered() {
+      firstUpdated() {
         this.inner = this.shadowRoot!.querySelector('x-inner1');
       }
     });
@@ -236,7 +236,7 @@ suite('Styling', () => {
         <x-inner2></x-inner2>`;
       }
 
-      firstRendered() {
+      firstUpdated() {
         this.inner = this.shadowRoot!.querySelector('x-inner2') as LitElement;
       }
     }

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -292,7 +292,7 @@ suite('ShadyDOM', () => {
     const div = el.shadowRoot!.querySelector('div');
     assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(), '6px');
     border = `4px solid orange`;
-    el.invalidate();
+    el.requestUpdate();
     await el.updateComplete;
     assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(), '6px');
   });

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -53,8 +53,8 @@ suite('LitElement', () => {
 
   test('invalidate waits until update/rendering', async () => {
     class E extends LitElement {
-      updated = 0;
-      render() { return html`${++this.updated}`; }
+      updateCount = 0;
+      render() { return html`${++this.updateCount}`; }
     }
     customElements.define(generateElementName(), E);
     const el = new E();
@@ -75,8 +75,8 @@ suite('LitElement', () => {
 
   test('updateComplete waits for invalidate but does not trigger invalidation, async', async () => {
     class E extends LitElement {
-      updated = 0;
-      render() { return html`${++this.updated}`; }
+      updateCount = 0;
+      render() { return html`${++this.updateCount}`; }
     }
     customElements.define(generateElementName(), E);
     const el = new E();
@@ -105,11 +105,11 @@ suite('LitElement', () => {
          class E extends LitElement {
 
            needsUpdate = true;
-           updated = 0;
+           updateCount = 0;
 
            shouldUpdate() { return this.needsUpdate; }
 
-           render() { return html`${++this.updated}`; }
+           render() { return html`${++this.updateCount}`; }
          }
          customElements.define(generateElementName(), E);
          const el = new E();
@@ -190,10 +190,10 @@ suite('LitElement', () => {
       toAttribute = 1;
       all = 10;
 
-      updated = 0;
+      updateCount = 0;
 
       update(changed: PropertyValues) {
-        this.updated++;
+        this.updateCount++;
         super.update(changed);
       }
 
@@ -204,7 +204,7 @@ suite('LitElement', () => {
     const el = new E();
     container.appendChild(el);
     await el.updateComplete;
-    assert.equal(el.updated, 1);
+    assert.equal(el.updateCount, 1);
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr');
     assert.equal(el.customAttr, 'customAttr');
@@ -221,7 +221,7 @@ suite('LitElement', () => {
     el.toAttribute = 2;
     el.all = 5;
     await el.updateComplete;
-    assert.equal(el.updated, 2);
+    assert.equal(el.updateCount, 2);
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr2');
     assert.equal(el.customAttr, 'customAttr2');
@@ -231,30 +231,30 @@ suite('LitElement', () => {
     assert.equal(el.all, 5);
     el.all = 15;
     await el.updateComplete;
-    assert.equal(el.updated, 3);
+    assert.equal(el.updateCount, 3);
     assert.equal(el.all, 15);
     assert.equal(el.getAttribute('all-attr'), '15-attr');
     el.setAttribute('all-attr', '16-attr');
     await el.updateComplete;
-    assert.equal(el.updated, 4);
+    assert.equal(el.updateCount, 4);
     assert.equal(el.getAttribute('all-attr'), '16-attr');
     assert.equal(el.all, 16);
     el.shouldInvalidate = 5;
     await el.updateComplete;
     assert.equal(el.shouldInvalidate, 5);
-    assert.equal(el.updated, 4);
+    assert.equal(el.updateCount, 4);
     el.shouldInvalidate = 15;
     await el.updateComplete;
     assert.equal(el.shouldInvalidate, 15);
-    assert.equal(el.updated, 5);
+    assert.equal(el.updateCount, 5);
     el.setAttribute('all-attr', '5-attr');
     await el.updateComplete;
     assert.equal(el.all, 5);
-    assert.equal(el.updated, 5);
+    assert.equal(el.updateCount, 5);
     el.all = 15;
     await el.updateComplete;
     assert.equal(el.all, 15);
-    assert.equal(el.updated, 6);
+    assert.equal(el.updateCount, 6);
   });
 
   test('property options via decorator', async() => {
@@ -279,10 +279,10 @@ suite('LitElement', () => {
       @property({attribute: 'all-attr', shouldInvalidate, type: {fromAttribute, toAttribute}, reflect: true})
       all = 10;
 
-      updated = 0;
+      updateCount = 0;
 
       update(changed: PropertyValues) {
-        this.updated++;
+        this.updateCount++;
         super.update(changed);
       }
 
@@ -293,7 +293,7 @@ suite('LitElement', () => {
     const el = new E();
     container.appendChild(el);
     await el.updateComplete;
-    assert.equal(el.updated, 1);
+    assert.equal(el.updateCount, 1);
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr');
     assert.equal(el.customAttr, 'customAttr');
@@ -310,7 +310,7 @@ suite('LitElement', () => {
     el.toAttribute = 2;
     el.all = 5;
     await el.updateComplete;
-    assert.equal(el.updated, 2);
+    assert.equal(el.updateCount, 2);
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr2');
     assert.equal(el.customAttr, 'customAttr2');
@@ -320,30 +320,30 @@ suite('LitElement', () => {
     assert.equal(el.all, 5);
     el.all = 15;
     await el.updateComplete;
-    assert.equal(el.updated, 3);
+    assert.equal(el.updateCount, 3);
     assert.equal(el.all, 15);
     assert.equal(el.getAttribute('all-attr'), '15-attr');
     el.setAttribute('all-attr', '16-attr');
     await el.updateComplete;
-    assert.equal(el.updated, 4);
+    assert.equal(el.updateCount, 4);
     assert.equal(el.getAttribute('all-attr'), '16-attr');
     assert.equal(el.all, 16);
     el.shouldInvalidate = 5;
     await el.updateComplete;
     assert.equal(el.shouldInvalidate, 5);
-    assert.equal(el.updated, 4);
+    assert.equal(el.updateCount, 4);
     el.shouldInvalidate = 15;
     await el.updateComplete;
     assert.equal(el.shouldInvalidate, 15);
-    assert.equal(el.updated, 5);
+    assert.equal(el.updateCount, 5);
     el.setAttribute('all-attr', '5-attr');
     await el.updateComplete;
     assert.equal(el.all, 5);
-    assert.equal(el.updated, 5);
+    assert.equal(el.updateCount, 5);
     el.all = 15;
     await el.updateComplete;
     assert.equal(el.all, 15);
-    assert.equal(el.updated, 6);
+    assert.equal(el.updateCount, 6);
   });
 
   test('attributes deserialize from html', async() => {
@@ -409,7 +409,7 @@ suite('LitElement', () => {
             [zug]: {}
           };
         }
-        updated = 0;
+        updateCount = 0;
         foo = 5;
         [zug] = 6;
 
@@ -418,7 +418,7 @@ suite('LitElement', () => {
         }
 
         update(changedProperties: PropertyValues) {
-          this.updated++;
+          this.updateCount++;
           super.update(changedProperties);
         }
 
@@ -427,17 +427,17 @@ suite('LitElement', () => {
       const el = new E();
       container.appendChild(el);
       await el.updateComplete;
-      assert.equal(el.updated, 1);
+      assert.equal(el.updateCount, 1);
       assert.equal(el.foo, 5);
       assert.equal(el[zug], 6);
       el.foo = 55;
       await el.updateComplete;
-      assert.equal(el.updated, 2);
+      assert.equal(el.updateCount, 2);
       assert.equal(el.foo, 55);
       assert.equal(el[zug], 6);
       el[zug] = 66;
       await el.updateComplete;
-      assert.equal(el.updated, 3);
+      assert.equal(el.updateCount, 3);
       assert.equal(el.foo, 55);
       assert.equal(el[zug], 66);
     });
@@ -502,10 +502,10 @@ suite('LitElement', () => {
       customAttr = 'customAttr';
       shouldInvalidate = 10;
 
-      updated = 0;
+      updateCount = 0;
 
       update(changed: PropertyValues) {
-        this.updated++;
+        this.updateCount++;
         super.update(changed);
       }
 
@@ -546,7 +546,7 @@ suite('LitElement', () => {
     const el = new G();
     container.appendChild(el);
     await el.updateComplete;
-    assert.equal(el.updated, 1);
+    assert.equal(el.updateCount, 1);
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr');
     assert.equal(el.customAttr, 'customAttr');
@@ -563,7 +563,7 @@ suite('LitElement', () => {
     el.toAttribute = 2;
     el.all = 5;
     await el.updateComplete;
-    assert.equal(el.updated, 2);
+    assert.equal(el.updateCount, 2);
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr2');
     assert.equal(el.customAttr, 'customAttr2');
@@ -573,30 +573,30 @@ suite('LitElement', () => {
     assert.equal(el.all, 5);
     el.all = 15;
     await el.updateComplete;
-    assert.equal(el.updated, 3);
+    assert.equal(el.updateCount, 3);
     assert.equal(el.all, 15);
     assert.equal(el.getAttribute('all-attr'), '15-attr');
     el.setAttribute('all-attr', '16-attr');
     await el.updateComplete;
-    assert.equal(el.updated, 4);
+    assert.equal(el.updateCount, 4);
     assert.equal(el.getAttribute('all-attr'), '16-attr');
     assert.equal(el.all, 16);
     el.shouldInvalidate = 5;
     await el.updateComplete;
     assert.equal(el.shouldInvalidate, 5);
-    assert.equal(el.updated, 4);
+    assert.equal(el.updateCount, 4);
     el.shouldInvalidate = 15;
     await el.updateComplete;
     assert.equal(el.shouldInvalidate, 15);
-    assert.equal(el.updated, 5);
+    assert.equal(el.updateCount, 5);
     el.setAttribute('all-attr', '5-attr');
     await el.updateComplete;
     assert.equal(el.all, 5);
-    assert.equal(el.updated, 5);
+    assert.equal(el.updateCount, 5);
     el.all = 15;
     await el.updateComplete;
     assert.equal(el.all, 15);
-    assert.equal(el.updated, 6);
+    assert.equal(el.updateCount, 6);
 
   });
 
@@ -740,15 +740,15 @@ suite('LitElement', () => {
       value = '1';
       attrValue = 'attr';
 
-      updatedValue = '';
-      updatedAttrValue = '';
+      updateCountValue = '';
+      updateCountAttrValue = '';
 
       render() { return html``; }
 
       update(props: PropertyValues) {
         super.update(props);
-        this.updatedValue = this.value;
-        this.updatedAttrValue = this.attrValue;
+        this.updateCountValue = this.value;
+        this.updateCountAttrValue = this.attrValue;
       }
     }
     customElements.define(generateElementName(), E);
@@ -756,25 +756,25 @@ suite('LitElement', () => {
     container.appendChild(el);
     assert.ok(el.shadowRoot);
     await el.updateComplete;
-    assert.equal(el.updatedValue, '1');
-    assert.equal(el.updatedAttrValue, 'attr');
+    assert.equal(el.updateCountValue, '1');
+    assert.equal(el.updateCountAttrValue, 'attr');
     el.value = '2';
     await el.updateComplete;
-    assert.equal(el.updatedValue, '2');
-    assert.equal(el.updatedAttrValue, 'attr');
+    assert.equal(el.updateCountValue, '2');
+    assert.equal(el.updateCountAttrValue, 'attr');
     el.attrValue = 'attr2';
     await el.updateComplete;
-    assert.equal(el.updatedValue, '2');
-    assert.equal(el.updatedAttrValue, 'attr2');
+    assert.equal(el.updateCountValue, '2');
+    assert.equal(el.updateCountAttrValue, 'attr2');
     el.setAttribute('attrvalue', 'attr3');
     await el.updateComplete;
-    assert.equal(el.updatedValue, '2');
-    assert.equal(el.updatedAttrValue, 'attr3');
+    assert.equal(el.updateCountValue, '2');
+    assert.equal(el.updateCountAttrValue, 'attr3');
     el.value = '3';
     el.setAttribute('attrvalue', 'attr4');
     await el.updateComplete;
-    assert.equal(el.updatedValue, '3');
-    assert.equal(el.updatedAttrValue, 'attr4');
+    assert.equal(el.updateCountValue, '3');
+    assert.equal(el.updateCountAttrValue, 'attr4');
   });
 
   test('updates/renders changes when attributes change', async () => {
@@ -839,7 +839,7 @@ suite('LitElement', () => {
     const shouldInvalidate = (value: any, old: any) => isNaN(old) || value > old;
     class E extends LitElement {
 
-      updated = 0;
+      updateCount = 0;
       __bar: any;
 
       static get properties() {
@@ -855,7 +855,7 @@ suite('LitElement', () => {
 
       update(changed: PropertyValues) {
         super.update(changed);
-        this.updated++;
+        this.updateCount++;
       }
 
       get bar() { return this.__bar; }
@@ -873,22 +873,22 @@ suite('LitElement', () => {
     const el = new E();
     container.appendChild(el);
     await el.updateComplete;
-    assert.equal(el.updated, 1);
+    assert.equal(el.updateCount, 1);
     assert.equal(el.bar, 5);
     assert.equal(el.getAttribute('attr-bar'), `5-attr`);
     el.setAttribute('attr-bar', '7');
     await el.updateComplete;
-    assert.equal(el.updated, 2);
+    assert.equal(el.updateCount, 2);
     assert.equal(el.bar, 7);
     assert.equal(el.getAttribute('attr-bar'), `7-attr`);
     el.bar = 4;
     await el.updateComplete;
-    assert.equal(el.updated, 2);
+    assert.equal(el.updateCount, 2);
     assert.equal(el.bar, 4);
     assert.equal(el.getAttribute('attr-bar'), `7-attr`);
     el.setAttribute('attr-bar', '3');
     await el.updateComplete;
-    assert.equal(el.updated, 2);
+    assert.equal(el.updateCount, 2);
     assert.equal(el.bar, 3);
     assert.equal(el.getAttribute('attr-bar'), `3`);
   });
@@ -920,21 +920,21 @@ suite('LitElement', () => {
     });
 
   test(
-      'firstRendered called when element first renders', async () => {
+      'firstUpdated called when element first updates', async () => {
         class E extends LitElement {
 
-          wasUpdated = 0;
-          wasFirstRendered = 0;
+          wasUpdatedCount = 0;
+          wasFirstUpdated = 0;
 
           update(changedProperties: PropertyValues) {
-            this.wasUpdated++;
+            this.wasUpdatedCount++;
             super.update(changedProperties);
           }
 
           render() { return html``; }
 
-          firstRendered() {
-            this.wasFirstRendered++;
+          firstUpdated() {
+            this.wasFirstUpdated++;
           }
 
         }
@@ -942,18 +942,18 @@ suite('LitElement', () => {
         const el = new E();
         container.appendChild(el);
         await el.updateComplete;
-        assert.equal(el.wasUpdated, 1);
-        assert.equal(el.wasFirstRendered, 1);
+        assert.equal(el.wasUpdatedCount, 1);
+        assert.equal(el.wasFirstUpdated, 1);
         await el.invalidate();
-        assert.equal(el.wasUpdated, 2);
-        assert.equal(el.wasFirstRendered, 1);
+        assert.equal(el.wasUpdatedCount, 2);
+        assert.equal(el.wasFirstUpdated, 1);
         await el.invalidate();
-        assert.equal(el.wasUpdated, 3);
-        assert.equal(el.wasFirstRendered, 1);
+        assert.equal(el.wasUpdatedCount, 3);
+        assert.equal(el.wasFirstUpdated, 1);
       });
 
   test(
-      'render lifecycle order: shouldUpdate, update, render, firstRendered, after update, updateComplete', async () => {
+      'render lifecycle order', async () => {
         class E extends LitElement {
           static get properties() { return {
             foo: {type: Number}
@@ -977,8 +977,12 @@ suite('LitElement', () => {
             this.info.push('after-update');
           }
 
-          firstRendered() {
-            this.info.push('firstRendered');
+          firstUpdated() {
+            this.info.push('firstUpdated');
+          }
+
+          updated() {
+            this.info.push('updated')
           }
 
         }
@@ -989,7 +993,7 @@ suite('LitElement', () => {
         el.info.push('updateComplete');
         assert.deepEqual(
             el.info,
-            [ 'shouldUpdate', 'before-update', 'render', 'firstRendered', 'after-update', 'updateComplete' ]);
+            [ 'shouldUpdate', 'before-update', 'render', 'after-update', 'firstUpdated', 'updated', 'updateComplete' ]);
       });
 
   test('setting properties in update does not trigger invalidation', async () => {
@@ -1002,10 +1006,10 @@ suite('LitElement', () => {
       }
       promiseFulfilled = false;
       foo = 0;
-      updated = 0;
+      updateCount = 0;
 
       update(props: PropertyValues) {
-        this.updated++;
+        this.updateCount++;
         this.foo++;
         super.update(props);
       }
@@ -1020,12 +1024,12 @@ suite('LitElement', () => {
     container.appendChild(el);
     await el.updateComplete;
     assert.equal(el.foo, 1);
-    assert.equal(el.updated, 1);
+    assert.equal(el.updateCount, 1);
     assert.equal(el.shadowRoot!.textContent, '1');
     el.foo = 5;
     await el.updateComplete;
     assert.equal(el.foo, 6);
-    assert.equal(el.updated, 2);
+    assert.equal(el.updateCount, 2);
     assert.equal(el.shadowRoot!.textContent, '6');
   });
 
@@ -1094,12 +1098,15 @@ suite('LitElement', () => {
         };
       }
       foo = 0;
-      updated = 0;
+      updateCount = 0;
       fooMax = 2;
 
       update(changed: PropertyValues) {
-        this.updated++;
+        this.updateCount++;
         super.update(changed);
+      }
+
+      updated() {
         if (this.foo < this.fooMax) {
           this.foo++;
         }
@@ -1116,16 +1123,16 @@ suite('LitElement', () => {
     let result = await el.updateComplete;
     assert.isFalse(result);
     assert.equal(el.foo, 1);
-    assert.equal(el.updated, 1);
+    assert.equal(el.updateCount, 1);
     result = await el.updateComplete;
     assert.isFalse(result);
     assert.equal(el.foo, 2);
-    assert.equal(el.updated, 2);
+    assert.equal(el.updateCount, 2);
     result = await el.updateComplete;
     assert.isTrue(result);
   });
 
-  test('setting properties after `super.update` can await until updateComplete returns true', async () => {
+  test('setting properties in `updated()` can await until updateComplete returns true', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1134,11 +1141,14 @@ suite('LitElement', () => {
         };
       }
       foo = 0;
-      updated = 0;
+      updateCount = 0;
 
       update(changed: PropertyValues) {
-        this.updated++;
+        this.updateCount++;
         super.update(changed);
+      }
+
+      updated(changed: PropertyValues) {
         if (this.foo < 10) {
           this.foo++;
         }
@@ -1156,7 +1166,7 @@ suite('LitElement', () => {
     assert.equal(el.foo, 10);
   });
 
-  test('updateComplete can block properties set after `super.update`', async () => {
+  test('updateComplete can block properties set in `updated()`', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1165,12 +1175,15 @@ suite('LitElement', () => {
         };
       }
       foo = 1;
-      updated = 0;
+      updateCount = 0;
       fooMax = 10;
 
       update(changed: PropertyValues) {
-        this.updated++;
+        this.updateCount++;
         super.update(changed);
+      }
+
+      updated() {
         if (this.foo < this.fooMax) {
           this.foo++;
         }
@@ -1191,7 +1204,7 @@ suite('LitElement', () => {
     const result = await el.updateComplete;
     assert.isTrue(result);
     assert.equal(el.foo, 10);
-    assert.equal(el.updated, 10);
+    assert.equal(el.updateCount, 10);
   });
 
   test('can await promise in updateComplete', async () => {
@@ -1229,6 +1242,45 @@ suite('LitElement', () => {
     assert.isTrue(el.promiseFulfilled);
   });
 
+  test('invalidate resolved at `updateComplete` time', async () => {
+    class E extends LitElement {
+
+      static get properties() {
+        return {
+          foo: {}
+        };
+      }
+      promiseFulfilled = false;
+      foo = 0;
+
+      render() {
+        return html`${this.foo}`;
+      }
+
+      get updateComplete() {
+        return (async () => {
+          return await super.updateComplete && await new Promise((resolve) => {
+            setTimeout(() => {
+              this.promiseFulfilled = true;
+              resolve(true);
+            }, 1);
+          });
+        })();
+      }
+
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    let result = await el.updateComplete;
+    assert.isTrue(result);
+    assert.isTrue(el.promiseFulfilled);
+    el.promiseFulfilled = false;
+    result = await el.invalidate() as boolean;
+    assert.isTrue(result);
+    assert.isTrue(el.promiseFulfilled);
+  });
+
   test('can await sub-element updateComplete', async () => {
     class E extends LitElement {
 
@@ -1262,7 +1314,7 @@ suite('LitElement', () => {
         return html`<x-1224></x-1224>`;
       }
 
-      firstRendered() {
+      firstUpdated() {
         this.inner = this.shadowRoot!.querySelector('x-1224');
       }
 
@@ -1352,7 +1404,7 @@ suite('LitElement', () => {
         return html`<x-2448 .foo="${this.bar}" attr="${this.bar}" .bool="${this.bool}"></x-2448>`;
       }
 
-      firstRendered() {
+      firstUpdated() {
         this.inner = this.shadowRoot!.querySelector('x-2448');
       }
 

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -1085,7 +1085,7 @@ suite('LitElement', () => {
           }
 
           updated() {
-            this.info.push('updated')
+            this.info.push('updated');
           }
 
         }
@@ -1306,7 +1306,7 @@ suite('LitElement', () => {
         super.update(changed);
       }
 
-      updated(changed: PropertyValues) {
+      updated() {
         if (this.foo < 10) {
           this.foo++;
         }

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -1026,8 +1026,12 @@ suite('LitElement', () => {
       '`firstUpdated` called when element first updates', async () => {
         class E extends LitElement {
 
+          @property()
+          foo = 1;
+
           wasUpdatedCount = 0;
           wasFirstUpdated = 0;
+          changedProperties: PropertyValues|undefined;
 
           update(changedProperties: PropertyValues) {
             this.wasUpdatedCount++;
@@ -1036,7 +1040,8 @@ suite('LitElement', () => {
 
           render() { return html``; }
 
-          firstUpdated() {
+          firstUpdated(changedProperties: PropertyValues) {
+            this.changedProperties = changedProperties;
             this.wasFirstUpdated++;
           }
 
@@ -1045,6 +1050,9 @@ suite('LitElement', () => {
         const el = new E();
         container.appendChild(el);
         await el.updateComplete;
+        const testMap = new Map();
+        testMap.set('foo', undefined);
+        assert.deepEqual(el.changedProperties, testMap);
         assert.equal(el.wasUpdatedCount, 1);
         assert.equal(el.wasFirstUpdated, 1);
         await el.requestUpdate();

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -51,7 +51,7 @@ suite('LitElement', () => {
     });
   });
 
-  test('invalidate waits until update/rendering', async () => {
+  test('`requestUpdate` waits until update/rendering', async () => {
     class E extends LitElement {
       updateCount = 0;
       render() { return html`${++this.updateCount}`; }
@@ -59,21 +59,21 @@ suite('LitElement', () => {
     customElements.define(generateElementName(), E);
     const el = new E();
     container.appendChild(el);
-    await el.invalidate();
+    await el.requestUpdate();
     assert.equal(
         stripExpressionDelimeters(el.shadowRoot!.innerHTML),
         '1');
-    await el.invalidate();
+    await el.requestUpdate();
     assert.equal(
         stripExpressionDelimeters(el.shadowRoot!.innerHTML),
         '2');
-    await el.invalidate();
+    await el.requestUpdate();
     assert.equal(
         stripExpressionDelimeters(el.shadowRoot!.innerHTML),
         '3');
   });
 
-  test('updateComplete waits for invalidate but does not trigger invalidation, async', async () => {
+  test('`updateComplete` waits for `requestUpdate` but does not trigger update, async', async () => {
     class E extends LitElement {
       updateCount = 0;
       render() { return html`${++this.updateCount}`; }
@@ -89,7 +89,7 @@ suite('LitElement', () => {
     assert.equal(
         stripExpressionDelimeters(el.shadowRoot!.innerHTML),
         '1');
-    el.invalidate();
+    el.requestUpdate();
     await el.updateComplete;
     assert.equal(
         stripExpressionDelimeters(el.shadowRoot!.innerHTML),
@@ -100,7 +100,7 @@ suite('LitElement', () => {
         '2');
   });
 
-  test('shouldUpdate controls update/rendering',
+  test('`shouldUpdate` controls update/rendering',
        async () => {
          class E extends LitElement {
 
@@ -119,16 +119,16 @@ suite('LitElement', () => {
              stripExpressionDelimeters(el.shadowRoot!.innerHTML),
              '1');
          el.needsUpdate = false;
-         await el.invalidate();
+         await el.requestUpdate();
          assert.equal(
              stripExpressionDelimeters(el.shadowRoot!.innerHTML),
              '1');
          el.needsUpdate = true;
-         await el.invalidate();
+         await el.requestUpdate();
          assert.equal(
              stripExpressionDelimeters(el.shadowRoot!.innerHTML),
              '2');
-         await el.invalidate();
+         await el.requestUpdate();
          assert.equal(
              stripExpressionDelimeters(el.shadowRoot!.innerHTML),
              '3');
@@ -166,7 +166,7 @@ suite('LitElement', () => {
 
   test('property options', async() => {
 
-    const shouldInvalidate = (value: any, old: any) => old === undefined || value > old;
+    const hasChanged = (value: any, old: any) => old === undefined || value > old;
     const fromAttribute = (value: any) => parseInt(value);
     const toAttribute = (value: any) => `${value}-attr`;
     class E extends LitElement {
@@ -175,17 +175,17 @@ suite('LitElement', () => {
           noAttr: {attribute: false},
           atTr: {attribute: true},
           customAttr: {attribute: 'custom', reflect: true},
-          shouldInvalidate: {shouldInvalidate},
+          hasChanged: {hasChanged},
           fromAttribute: {type: fromAttribute},
           toAttribute: {reflect: true, type: {toAttribute}},
-          all: {attribute: 'all-attr', shouldInvalidate, type: {fromAttribute, toAttribute}, reflect: true},
+          all: {attribute: 'all-attr', hasChanged, type: {fromAttribute, toAttribute}, reflect: true},
         };
       }
 
       noAttr = 'noAttr';
       atTr = 'attr';
       customAttr = 'customAttr';
-      shouldInvalidate = 10;
+      hasChanged = 10;
       fromAttribute = 1;
       toAttribute = 1;
       all = 10;
@@ -208,7 +208,7 @@ suite('LitElement', () => {
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr');
     assert.equal(el.customAttr, 'customAttr');
-    assert.equal(el.shouldInvalidate, 10);
+    assert.equal(el.hasChanged, 10);
     assert.equal(el.fromAttribute, 1);
     assert.equal(el.toAttribute, 1);
     assert.equal(el.getAttribute('toattribute'), '1-attr');
@@ -239,13 +239,13 @@ suite('LitElement', () => {
     assert.equal(el.updateCount, 4);
     assert.equal(el.getAttribute('all-attr'), '16-attr');
     assert.equal(el.all, 16);
-    el.shouldInvalidate = 5;
+    el.hasChanged = 5;
     await el.updateComplete;
-    assert.equal(el.shouldInvalidate, 5);
+    assert.equal(el.hasChanged, 5);
     assert.equal(el.updateCount, 4);
-    el.shouldInvalidate = 15;
+    el.hasChanged = 15;
     await el.updateComplete;
-    assert.equal(el.shouldInvalidate, 15);
+    assert.equal(el.hasChanged, 15);
     assert.equal(el.updateCount, 5);
     el.setAttribute('all-attr', '5-attr');
     await el.updateComplete;
@@ -259,7 +259,7 @@ suite('LitElement', () => {
 
   test('property options via decorator', async() => {
 
-    const shouldInvalidate = (value: any, old: any) => old === undefined || value > old;
+    const hasChanged = (value: any, old: any) => old === undefined || value > old;
     const fromAttribute = (value: any) => parseInt(value);
     const toAttribute = (value: any) => `${value}-attr`;
     class E extends LitElement {
@@ -270,13 +270,13 @@ suite('LitElement', () => {
       atTr = 'attr';
       @property({attribute: 'custom', reflect: true})
       customAttr = 'customAttr';
-      @property({shouldInvalidate})
-      shouldInvalidate = 10;
+      @property({hasChanged})
+      hasChanged = 10;
       @property({type: fromAttribute})
       fromAttribute = 1;
       @property({reflect: true, type: {toAttribute}})
       toAttribute = 1;
-      @property({attribute: 'all-attr', shouldInvalidate, type: {fromAttribute, toAttribute}, reflect: true})
+      @property({attribute: 'all-attr', hasChanged, type: {fromAttribute, toAttribute}, reflect: true})
       all = 10;
 
       updateCount = 0;
@@ -297,7 +297,7 @@ suite('LitElement', () => {
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr');
     assert.equal(el.customAttr, 'customAttr');
-    assert.equal(el.shouldInvalidate, 10);
+    assert.equal(el.hasChanged, 10);
     assert.equal(el.fromAttribute, 1);
     assert.equal(el.toAttribute, 1);
     assert.equal(el.getAttribute('toattribute'), '1-attr');
@@ -328,13 +328,13 @@ suite('LitElement', () => {
     assert.equal(el.updateCount, 4);
     assert.equal(el.getAttribute('all-attr'), '16-attr');
     assert.equal(el.all, 16);
-    el.shouldInvalidate = 5;
+    el.hasChanged = 5;
     await el.updateComplete;
-    assert.equal(el.shouldInvalidate, 5);
+    assert.equal(el.hasChanged, 5);
     assert.equal(el.updateCount, 4);
-    el.shouldInvalidate = 15;
+    el.hasChanged = 15;
     await el.updateComplete;
-    assert.equal(el.shouldInvalidate, 15);
+    assert.equal(el.hasChanged, 15);
     assert.equal(el.updateCount, 5);
     el.setAttribute('all-attr', '5-attr');
     await el.updateComplete;
@@ -348,18 +348,18 @@ suite('LitElement', () => {
 
   test('can mix property options via decorator and via getter', async() => {
 
-    const shouldInvalidate = (value: any, old: any) => old === undefined || value > old;
+    const hasChanged = (value: any, old: any) => old === undefined || value > old;
     const fromAttribute = (value: any) => parseInt(value);
     const toAttribute = (value: any) => `${value}-attr`;
     class E extends LitElement {
 
-      @property({shouldInvalidate})
-      shouldInvalidate = 10;
+      @property({hasChanged})
+      hasChanged = 10;
       @property({type: fromAttribute})
       fromAttribute = 1;
       @property({reflect: true, type: {toAttribute}})
       toAttribute = 1;
-      @property({attribute: 'all-attr', shouldInvalidate, type: {fromAttribute, toAttribute}, reflect: true})
+      @property({attribute: 'all-attr', hasChanged, type: {fromAttribute, toAttribute}, reflect: true})
       all = 10;
 
       updateCount = 0;
@@ -399,7 +399,7 @@ suite('LitElement', () => {
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr');
     assert.equal(el.customAttr, 'customAttr');
-    assert.equal(el.shouldInvalidate, 10);
+    assert.equal(el.hasChanged, 10);
     assert.equal(el.fromAttribute, 1);
     assert.equal(el.toAttribute, 1);
     assert.equal(el.getAttribute('toattribute'), '1-attr');
@@ -430,13 +430,13 @@ suite('LitElement', () => {
     assert.equal(el.updateCount, 4);
     assert.equal(el.getAttribute('all-attr'), '16-attr');
     assert.equal(el.all, 16);
-    el.shouldInvalidate = 5;
+    el.hasChanged = 5;
     await el.updateComplete;
-    assert.equal(el.shouldInvalidate, 5);
+    assert.equal(el.hasChanged, 5);
     assert.equal(el.updateCount, 4);
-    el.shouldInvalidate = 15;
+    el.hasChanged = 15;
     await el.updateComplete;
-    assert.equal(el.shouldInvalidate, 15);
+    assert.equal(el.hasChanged, 15);
     assert.equal(el.updateCount, 5);
     el.setAttribute('all-attr', '5-attr');
     await el.updateComplete;
@@ -586,7 +586,7 @@ suite('LitElement', () => {
 
   test('property options compose when subclassing', async() => {
 
-    const shouldInvalidate = (value: any, old: any) => old === undefined || value > old;
+    const hasChanged = (value: any, old: any) => old === undefined || value > old;
     const fromAttribute = (value: any) => parseInt(value);
     const toAttribute = (value: any) => `${value}-attr`;
     class E extends LitElement {
@@ -595,14 +595,14 @@ suite('LitElement', () => {
           noAttr: {attribute: false},
           atTr: {attribute: true},
           customAttr: {},
-          shouldInvalidate: {},
+          hasChanged: {},
         };
       }
 
       noAttr = 'noAttr';
       atTr = 'attr';
       customAttr = 'customAttr';
-      shouldInvalidate = 10;
+      hasChanged = 10;
 
       updateCount = 0;
 
@@ -620,7 +620,7 @@ suite('LitElement', () => {
       static get properties(): PropertyDeclarations {
         return {
           customAttr: {attribute: 'custom', reflect: true},
-          shouldInvalidate: {shouldInvalidate},
+          hasChanged: {hasChanged},
           fromAttribute: {},
           toAttribute: {},
         };
@@ -637,7 +637,7 @@ suite('LitElement', () => {
         return {
           fromAttribute: {type: fromAttribute},
           toAttribute: {reflect: true, type: {toAttribute}},
-          all: {attribute: 'all-attr', shouldInvalidate, type: {fromAttribute, toAttribute}, reflect: true},
+          all: {attribute: 'all-attr', hasChanged, type: {fromAttribute, toAttribute}, reflect: true},
         };
       }
 
@@ -652,7 +652,7 @@ suite('LitElement', () => {
     assert.equal(el.noAttr, 'noAttr');
     assert.equal(el.atTr, 'attr');
     assert.equal(el.customAttr, 'customAttr');
-    assert.equal(el.shouldInvalidate, 10);
+    assert.equal(el.hasChanged, 10);
     assert.equal(el.fromAttribute, 1);
     assert.equal(el.toAttribute, 1);
     assert.equal(el.getAttribute('toattribute'), '1-attr');
@@ -683,13 +683,13 @@ suite('LitElement', () => {
     assert.equal(el.updateCount, 4);
     assert.equal(el.getAttribute('all-attr'), '16-attr');
     assert.equal(el.all, 16);
-    el.shouldInvalidate = 5;
+    el.hasChanged = 5;
     await el.updateComplete;
-    assert.equal(el.shouldInvalidate, 5);
+    assert.equal(el.hasChanged, 5);
     assert.equal(el.updateCount, 4);
-    el.shouldInvalidate = 15;
+    el.hasChanged = 15;
     await el.updateComplete;
-    assert.equal(el.shouldInvalidate, 15);
+    assert.equal(el.hasChanged, 15);
     assert.equal(el.updateCount, 5);
     el.setAttribute('all-attr', '5-attr');
     await el.updateComplete;
@@ -916,8 +916,9 @@ suite('LitElement', () => {
       get bar() { return this.__bar; }
 
       set bar(value) {
+        const old = this.bar;
         this.__bar = Number(value);
-        this.invalidate();
+        this.requestUpdate('bar', old);
       }
 
       render() {
@@ -935,10 +936,10 @@ suite('LitElement', () => {
     assert.equal(stripExpressionDelimeters(el.shadowRoot!.innerHTML), '020');
   });
 
-  test('User defined accessor can use property options via `invalidateProperty`', async () => {
+  test('User defined accessor can use property options via `requestUpdate`', async () => {
     const fromAttribute = (value: any) => parseInt(value);
     const toAttribute = (value: any) => `${value}-attr`;
-    const shouldInvalidate = (value: any, old: any) => isNaN(old) || value > old;
+    const hasChanged = (value: any, old: any) => isNaN(old) || value > old;
     class E extends LitElement {
 
       updateCount = 0;
@@ -946,7 +947,7 @@ suite('LitElement', () => {
 
       static get properties() {
         return {
-          bar: {attribute: 'attr-bar', reflect: true, type: {fromAttribute, toAttribute}, shouldInvalidate}
+          bar: {attribute: 'attr-bar', reflect: true, type: {fromAttribute, toAttribute}, hasChanged}
         };
       }
 
@@ -965,7 +966,7 @@ suite('LitElement', () => {
       set bar(value) {
         const old = this.bar;
         this.__bar = Number(value);
-        this.invalidateProperty('bar', old);
+        this.requestUpdate('bar', old);
       }
 
       render() { return html``; }
@@ -995,7 +996,7 @@ suite('LitElement', () => {
     assert.equal(el.getAttribute('attr-bar'), `3`);
   });
 
-  test('updates/renders attributes, properties, and event listeners via lit-html',
+  test('updates/renders attributes, properties, and event listeners via `lit-html`',
     async () => {
       class E extends LitElement {
         _event?: Event;
@@ -1022,7 +1023,7 @@ suite('LitElement', () => {
     });
 
   test(
-      'firstUpdated called when element first updates', async () => {
+      '`firstUpdated` called when element first updates', async () => {
         class E extends LitElement {
 
           wasUpdatedCount = 0;
@@ -1046,10 +1047,10 @@ suite('LitElement', () => {
         await el.updateComplete;
         assert.equal(el.wasUpdatedCount, 1);
         assert.equal(el.wasFirstUpdated, 1);
-        await el.invalidate();
+        await el.requestUpdate();
         assert.equal(el.wasUpdatedCount, 2);
         assert.equal(el.wasFirstUpdated, 1);
-        await el.invalidate();
+        await el.requestUpdate();
         assert.equal(el.wasUpdatedCount, 3);
         assert.equal(el.wasFirstUpdated, 1);
       });
@@ -1098,7 +1099,7 @@ suite('LitElement', () => {
             [ 'shouldUpdate', 'before-update', 'render', 'after-update', 'firstUpdated', 'updated', 'updateComplete' ]);
       });
 
-  test('setting properties in update does not trigger invalidation', async () => {
+  test('setting properties in update does not trigger update', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1191,7 +1192,7 @@ suite('LitElement', () => {
     assert.equal(el.getAttribute('zot'), '3');
   });
 
-  test('can make properties for native accessors and render', async () => {
+  test('can make properties for native accessors', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1246,7 +1247,7 @@ suite('LitElement', () => {
     assert.equal((window as any).id2, el);
   });
 
-  test('setting properties in `updated` does trigger invalidation and does not block updateComplete', async () => {
+  test('setting properties in `updated` does trigger update and does not block updateComplete', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1289,7 +1290,7 @@ suite('LitElement', () => {
     assert.isTrue(result);
   });
 
-  test('setting properties in `updated()` can await until updateComplete returns true', async () => {
+  test('setting properties in `updated` can await until updateComplete returns true', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1323,7 +1324,7 @@ suite('LitElement', () => {
     assert.equal(el.foo, 10);
   });
 
-  test('updateComplete can block properties set in `updated()`', async () => {
+  test('`updateComplete` can block properties set in `updated`', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1364,7 +1365,7 @@ suite('LitElement', () => {
     assert.equal(el.updateCount, 10);
   });
 
-  test('can await promise in updateComplete', async () => {
+  test('can await promise in `updateComplete`', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1399,7 +1400,7 @@ suite('LitElement', () => {
     assert.isTrue(el.promiseFulfilled);
   });
 
-  test('invalidate resolved at `updateComplete` time', async () => {
+  test('`requestUpdate` resolved at `updateComplete` time', async () => {
     class E extends LitElement {
 
       static get properties() {
@@ -1433,12 +1434,12 @@ suite('LitElement', () => {
     assert.isTrue(result);
     assert.isTrue(el.promiseFulfilled);
     el.promiseFulfilled = false;
-    result = await el.invalidate() as boolean;
+    result = await el.requestUpdate() as boolean;
     assert.isTrue(result);
     assert.isTrue(el.promiseFulfilled);
   });
 
-  test('can await sub-element updateComplete', async () => {
+  test('can await sub-element `updateComplete`', async () => {
     class E extends LitElement {
 
       static get properties() {


### PR DESCRIPTION
**Adds**
* `updated`: called after the element updates and used to directly manipulate element DOM, for example focusing an element. Previously this code was written in `update` after calling `super.update`.

**Changes**
* `firstUpdated`: This was previously `firstRendered` and was changed to expose only one entry point using the "render" terminology.
* `requestUpdate`: This was previously `invalidate` and `invalidateProperty`. This one method now does double duty and was changed so we consistently use the "update" concept.
* `hasChanged`: This was previously `shouldInvalidate` and was changed to indicate meaning rather than what action is taken as a result.