### PR TITLE
Ensure `firstUpdated` is always called when the element first updated

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -506,18 +506,15 @@ export abstract class UpdatingElement extends HTMLElement {
       const needsFirstUpdate = !(this._updateState & STATE_HAS_UPDATED);
       this._markUpdated();
       if (needsFirstUpdate) {
+        this._updateState = this._updateState | STATE_HAS_UPDATED;
         this.firstUpdated(changedProperties);
       }
       this.updated(changedProperties);
     } else {
-      this._markNotUpdated();
+      this._markUpdated();
     }
   }
   private _markUpdated() {
-    this._changedProperties = new Map();
-    this._updateState = this._updateState & ~STATE_UPDATE_REQUESTED | STATE_HAS_UPDATED;
-  }
-  private _markNotUpdated() {
     this._changedProperties = new Map();
     this._updateState = this._updateState & ~STATE_UPDATE_REQUESTED;
   }

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -510,13 +510,16 @@ export abstract class UpdatingElement extends HTMLElement {
       }
       this.updated(changedProperties);
     } else {
-      this._markUpdated();
+      this._markNotUpdated();
     }
   }
-
   private _markUpdated() {
     this._changedProperties = new Map();
     this._updateState = this._updateState & ~STATE_UPDATE_REQUESTED | STATE_HAS_UPDATED;
+  }
+  private _markNotUpdated() {
+    this._changedProperties = new Map();
+    this._updateState = this._updateState & ~STATE_UPDATE_REQUESTED;
   }
 
   /**

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -1064,6 +1064,56 @@ suite('LitElement', () => {
       });
 
   test(
+      '`firstUpdated` called when element first updates even if first `shouldUpdate` returned false', async () => {
+        class E extends LitElement {
+
+          @property()
+          foo = 1;
+
+          triedToUpdatedCount = 0;
+          wasUpdatedCount = 0;
+          wasFirstUpdated = 0;
+          changedProperties: PropertyValues|undefined;
+
+          shouldUpdate() {
+              this.triedToUpdatedCount++;
+              return this.triedToUpdatedCount > 1;
+          }
+
+          update(changedProperties: PropertyValues) {
+            this.wasUpdatedCount++;
+            super.update(changedProperties);
+          }
+
+          render() { return html ``; }
+
+          firstUpdated(changedProperties: PropertyValues) {
+            this.changedProperties = changedProperties;
+            this.wasFirstUpdated++;
+          }
+        }
+
+        customElements.define(generateElementName(), E);
+        const el = new E();
+        container.appendChild(el);
+        await el.updateComplete;
+        const testMap = new Map();
+        testMap.set('foo', undefined);
+        assert.equal(el.triedToUpdatedCount, 1);
+        assert.equal(el.wasUpdatedCount, 0);
+        assert.equal(el.wasFirstUpdated, 0);
+        await el.requestUpdate();
+        assert.deepEqual(el.changedProperties, testMap);
+        assert.equal(el.triedToUpdatedCount, 2);
+        assert.equal(el.wasUpdatedCount, 1);
+        assert.equal(el.wasFirstUpdated, 1);
+        await el.requestUpdate();
+        assert.equal(el.triedToUpdatedCount, 3);
+        assert.equal(el.wasUpdatedCount, 2);
+        assert.equal(el.wasFirstUpdated, 1);
+    });
+
+  test(
       'render lifecycle order', async () => {
         class E extends LitElement {
           static get properties() { return {


### PR DESCRIPTION


<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
Fix #172
<!-- Example: Fixes #1234 -->

As described in #172, the `firstUpdated` lifecycle method is not always called. 

The problem was in the `_validate()` method of `lib/update-element.ts`:

```TypeScript
  private _validate() {
    // Mixin instance properties once, if they exist.
    if (this._instanceProperties) {
      this._applyInstanceProperties();
    }
    if (this.shouldUpdate(this._changedProperties)) {
      const changedProperties = this._changedProperties;
      this.update(changedProperties);
      const needsFirstUpdate = !(this._updateState & STATE_HAS_UPDATED);
      this._markUpdated();
      if (needsFirstUpdate) {
        this.firstUpdated(changedProperties);
      }
      this.updated(changedProperties);
    } else {
      this._markUpdated();
    }
  }
  private _markUpdated() {
    this._changedProperties = new Map();
    this._updateState = this._updateState & ~STATE_UPDATE_REQUESTED | STATE_HAS_UPDATED;
  }
```

If `shouldUpdated` return false, the element is still marked as *updated* in  `_markUpdated`, but the element isn't updated. 
So if the first time the element tries to update `shouldUpdated` return false, the element is marked as updated. Then when the element is really going to be updated, the check `const needsFirstUpdate = !(this._updateState & STATE_HAS_UPDATED);` is false, and `firstUpdated` isn't called. 

I have added a new test case to test this problem, and the version 0.6.0-dev.6 doesn't pass it.
Then I have modified `lib/update-element.ts` with a new `_markNotUpdated()` method that is called when `shouldUpdate` returns false, and that doesn't mark the element as *updated*.

With that fix `firstUpdated` is always called the first time and all the other tests are still valid.