### PR TITLE
Add disconnectedCallback stub.

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -397,6 +397,13 @@ export abstract class UpdatingElement extends HTMLElement {
   }
 
   /**
+   * Allows for `super.disconnectedCallback()` in extensions while
+   * reserving the positibility of making non-breaking feature additions
+   * when disconnecting at some point in the future.
+   */
+  disconnectedCallback() {}
+
+  /**
    * Synchronizes property values when attributes change.
    */
   attributeChangedCallback(name: string, old: string, value: string) {


### PR DESCRIPTION
Fixes #212

Disconnected stub allows for feature additions in the disconnect phase of the element lifecycle as needed without it being a breaking change, while making it possible to apply `super.disconnectedCallback()` in all extensions.
