### PR TITLE
export attribute deserializer interface

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -15,7 +15,7 @@
 /**
  * Converts property values to and from attribute values.
  */
-interface AttributeSerializer<T = any> {
+export interface AttributeSerializer<T = any> {
 
   /**
    * Deserializing function called to convert an attribute value to a property


### PR DESCRIPTION
While this type can be inferred in most cases, it would be useful to export it for places where we want a strongly typed serializer which isn't part of the properties map (yet).

would this be fine? 