### PR TITLE
Fix import path in minimal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ into the element.
 ```html
   <script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
   <script type="module">
-    import {LitElement, html} from '@polymer/lit-element';
+    import {LitElement, html} from './node_modules/@polymer/lit-element/lit-element.js';
 
     class MyElement extends LitElement {
 


### PR DESCRIPTION
Import paths must be absolute URLs or start with `/`, `./` or `../`.

Note that the minimal example still doesn't work because lit-element imports from `'lit-html'`, which won't work, but at least the code example looks right now.
