### PR TITLE
Added reference to lit-html guide for how to create templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 LitElement uses [lit-html](https://github.com/Polymer/lit-html) to render into the
 element's [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM)
 and adds API to help manage element properties and attributes. LitElement reacts to changes in properties
-and renders declaratively using `lit-html`.
+and renders declaratively using `lit-html`. See the [lit-html guide](https://polymer.github.io/lit-html/guide)
+for additional information on how to create templates for lit-element.
 
   * **Setup properties:** LitElement supports observable properties that cause the element to update.
   These properties can be declared in a few ways:


### PR DESCRIPTION
I was trying to find the documentation for the lit-html API for how to write templates but had some problems finding it. I suspect I'm not alone, so I added a sentence and a link to the lit-html guide to make it easier to find.