### PR TITLE
Add syntax example for boolean attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ and renders declaratively using `lit-html`.
     * expression: ``` html`<div>${this.disabled ? 'Off' : 'On'}</div>` ```
     * property: ``` html`<x-foo .bar="${this.bar}"></x-foo>` ```
     * attribute: ``` html`<div class="${this.color} special"></div>` ```
+    * boolean attribute: ``` html`<input type="checkbox" ?checked=${checked}>` ```
     * event handler: ``` html`<button @click="${this._clickHandler}"></button>` ```
 
 ## Getting started


### PR DESCRIPTION
Readme was missing an example for setting boolean attributes. Added the same example that is used in the lit-html documentation.