### PR TITLE
Enable TypeScript declaration maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,15 @@
 lit-element.js
 lit-element.js.map
 lit-element.d.ts
+lit-element.d.ts.map
 
 /test/**/*.d.ts
+/test/**/*.d.ts.map
 /test/**/*.js
 /test/**/*.js.map
 
 /demo/**/*.d.ts
+/demo/**/*.d.ts.map
 /demo/**/*.js
 /demo/**/*.js.map
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "lib": ["es2017", "dom"],
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "inlineSources": true,
     "strict": true,


### PR DESCRIPTION
This makes go to definition take users of the module go to the correct
file in src/ in their editor.

Same as Polymer/lit-html#528
