### PR TITLE
Explicitly annotate render's return type

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -51,7 +51,6 @@ export class LitElement extends UpdatingElement {
    * Invoked on each update to perform rendering tasks. This method must return
    * a lit-html TemplateResult. Setting properties inside this method will *not*
    * trigger the element to update.
-   * @returns {TemplateResult} Must return a lit-html TemplateResult.
    */
   protected render(): TemplateResult|void {}
 }

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -53,5 +53,5 @@ export class LitElement extends UpdatingElement {
    * trigger the element to update.
    * @returns {TemplateResult} Must return a lit-html TemplateResult.
    */
-  protected render() {}
+  protected render(): TemplateResult|void {}
 }


### PR DESCRIPTION
This way, an overriding class will get a type error if their render function returns something that isn't a TemplateResult.
