### PR TITLE
fix: Fix typing issue with @customElement

### DIFF
--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -21,6 +21,10 @@ export type Constructor<T> = {
   new (...args: any[]): T
 };
 
+
+type CustomElementDecorator<N> = (tagName: keyof N) =>
+(clazz: Constructor<HTMLElement>) => any;
+
 /**
  * Class decorator factory that defines the decorated class as a custom element.
  *
@@ -40,8 +44,9 @@ export type Constructor<T> = {
  *     }
  *
  */
-export const customElement = (tagName: keyof HTMLElementTagNameMap) =>
-    (clazz: Constructor<HTMLElement>) => {
+
+export const customElement: CustomElementDecorator<HTMLElementTagNameMap> = (tagName) =>
+    (clazz) => {
       window.customElements.define(tagName, clazz);
       // Cast as any because TS doesn't recognize the return type as being a
       // subtype of the decorated class when clazz is typed as


### PR DESCRIPTION
Fixes #291

It appears the issue is with TypeScript optimizing the `keyof` statement for the declaration file. This hack should stop TypeScript from optimizing and make it behave as expected.

This would be an alternative to PR #292