### PR TITLE
Protect validate invalidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Setting properties inside this method will trigger the element to update.
 * `updateComplete` Promise is resolved with a boolean that is `true` if the
 element is not pending another update, and any code awaiting the element's
 `updateComplete` Promise runs and observes the element in the updated state.
+* `invalidate()`: Called whenever a property is changed.
+* `validate()`: Manages validating the element by updating it.
 
 ## Bigger Example
 

--- a/demo/lit-element.html
+++ b/demo/lit-element.html
@@ -47,7 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       set zot(value) {
         this.setAttribute('zot', value);
-        this.invalidate();
+        this.requestUpdate();
       }
 
 

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -474,7 +474,7 @@ export abstract class UpdatingElement extends HTMLElement {
                       defaultPropertyDeclaration;
       return this._requestPropertyUpdate(name, oldValue, options);
     }
-    return this._invalidate();
+    return this.invalidate();
   }
 
   /**
@@ -501,7 +501,7 @@ export abstract class UpdatingElement extends HTMLElement {
       }
       this._reflectingProperties.set(name, options);
     }
-    return this._invalidate();
+    return this.invalidate();
   }
 
   /**
@@ -509,7 +509,7 @@ export abstract class UpdatingElement extends HTMLElement {
    * of whether or not any property changes are pending. This method is
    * automatically called when any registered property changes.
    */
-  private async _invalidate() {
+  protected async invalidate() {
     if (!this._hasRequestedUpdate) {
       // mark state updating...
       this._updateState = this._updateState | STATE_UPDATE_REQUESTED;
@@ -517,7 +517,7 @@ export abstract class UpdatingElement extends HTMLElement {
       const previousValidatePromise = this._updatePromise;
       this._updatePromise = new Promise((r) => resolver = r);
       await previousValidatePromise;
-      this._validate();
+      this.validate();
       resolver!(!this._hasRequestedUpdate);
     }
     return this.updateComplete;
@@ -530,7 +530,7 @@ export abstract class UpdatingElement extends HTMLElement {
   /**
    * Validates the element by updating it.
    */
-  private _validate() {
+  protected validate() {
     // Mixin instance properties once, if they exist.
     if (this._instanceProperties) {
       this._applyInstanceProperties();


### PR DESCRIPTION
Fixes: #290

- update `invalidate` and `validate` from _private_ to _protected_
- correct the demo to the most recent API
- add lifecycle method documentation to README.
