### PR TITLE
use AddEventListenerOptions for event decorator

### DIFF
--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -116,7 +116,7 @@ function _query<T>(queryFn: (target: NodeSelector, selector: string) => T) {
  *       }
  *     }
  */
-export const eventOptions = (options: EventListenerOptions) =>
+export const eventOptions = (options: AddEventListenerOptions) =>
     (proto: any, name: string) => {
       // This comment is here to fix a disagreement between formatter and linter
       Object.assign(proto[name], options);


### PR DESCRIPTION
As you can see [here](https://github.com/Polymer/lit-html/blob/3172fbd32fd6b08cee1b3d3cea2505b4a46c1998/src/lib/parts.ts#L418), it seems we should really be using `AddEventListenerOptions` in our decorator (i know this isn't necessarily of the same type, though).

`EventListenerOptions` doesn't contain `passive` and what not, so this doesn't seem correct as it currently is.