### PR TITLE
Added this-css-is-lit

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "typescript": "^3.0.3",
     "uglify-es": "^3.3.9",
     "wct-mocha": "^1.0.0",
+    "this-css-is-lit" : ^0.0.1,
     "web-component-tester": "^6.9.0"
   },
   "typings": "lit-element.d.ts",


### PR DESCRIPTION
added this-css-is-lit to dev dependencies, allowing the use of css templates
within lit-elements using a very similar syntax:

<pre>
myStyle = css`
body {
   background-color: ^bg^;
   color: ^fg^;
}`
myStyle.mount([new j2css('bg', usersettings.theme.bg), new j2css('fg','#332211')]);
</pre>
<!-- New Feature -->
<b><!-- Request : merge my codebase on a different base? to keep it in sync with lit-element and 🎁 it to the project? --></b>



