### PR TITLE
introduce default type serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -->
 
 <!-- ## Unreleased -->
+* Introduced primitive serialization support (Object, String, Boolean, Number
+and Array) as the `type` option when configuring a property, while
+allowing custom serializers through use of the `serializer` option
 
 <!-- ### Changed -->
 <!-- ### Added -->

--- a/src/demo/ts-element.ts
+++ b/src/demo/ts-element.ts
@@ -4,7 +4,10 @@ class TSElement extends LitElement {
 
   @property() message = 'Hi';
 
-  @property({attribute : 'more-info', type: (value: string) => `[${value}]`})
+  @property({
+    attribute : 'more-info',
+    serializer: (value: string) => `[${value}]`
+  })
   extra = '';
 
   render() {

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -355,7 +355,7 @@ export abstract class UpdatingElement extends HTMLElement {
     const type = options && options.type;
     let serializer = options && options.serializer;
 
-    if (type !== undefined) {
+    if (serializer === undefined && type !== undefined) {
       serializer = getDefaultSerializer(type);
     }
 
@@ -385,7 +385,7 @@ export abstract class UpdatingElement extends HTMLElement {
     const type = options && options.type;
     let serializer = options && options.serializer;
 
-    if (type !== undefined) {
+    if (serializer === undefined && type !== undefined) {
       serializer = getDefaultSerializer(type);
     }
 


### PR DESCRIPTION
Fixes #264.

Maybe this is a solution?

* The old `type` option has been renamed to `serializer`
* `type` is now one of the primitive constructors (`Boolean`, `String`, `Number`, `Object` or `Array`) if set
* `AttributeSerializer` has been renamed to `ComplexAttributeSerializer`
* `AttributeType` has been renamed to `AttributeSerializer`
* `AttributeType` is a type alias for the basic primitive constructors
* Deserialization and serialization checks for a default serializer if none is specified and a type has been

This would reduce some confusion, especially for those coming from Polymer, as the type system will be _almost_ the same (there is no support for `Date`). Additionally, much of the content out there about lit mistakenly uses `type: Object` often, so this alone tells me people are assuming that is the correct syntax already.

Examples:

```typescript
@property({ type: Object })
@property({ serializer: (val) => customSerializer(val) })
@property({
  serializer: {
    toAttribute(val) { return `${val}`; },
    fromAttribute(val) { return JSON.parse(val); }
  }
});
```

When using something like `type: Object`, the following occurs:

```js
el.myProp = { a: 5 }; // myprop='{"a":5}'
el.setAttribute('myprop', '{"a":6}'); // myProp === 6
```

If you have better ideas or other plans, im happy to close, just figured i'd push this since I had it.

cc @sorvell 