### PR TITLE
[Docs] Fix property type - function case

### DIFF
--- a/docs/_guide/properties.md
+++ b/docs/_guide/properties.md
@@ -118,10 +118,10 @@ By default, LitElement uses the `String` constructor to serialize and deserializ
 
 `type` can be: 
 
-* A function that performs both serialization and deserialization:
+* A function that performs the deserialization (i.e. returns the property value from the attribute value). The `String` constructor is used to reflect the property value to the attribute.
 
   ```js
-  propName: { type: someFunction }
+  propName: { type: deserializerFunction }
   ```
 
 * An object with two function properties, `fromAttribute` and `toAttribute`. `fromAttribute` performs deserialization, and `toAttribute` performs serialization:


### PR DESCRIPTION
The serialization (`.toAttribute`) is handled by `String` at https://github.com/Polymer/lit-element/blob/4b20f80bc3145b0a0f7421f23d9a9f9e3d43e922/src/lib/updating-element.ts#L293-L298
