### PR TITLE
Added TemplateResult to exports

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -18,7 +18,7 @@ import {PropertyValues, UpdatingElement} from './lib/updating-element.js';
 
 export * from './lib/updating-element.js';
 export * from './lib/decorators.js';
-export {html, svg, TemplateResult} from 'lit-html/lit-html';
+export {html, svg, TemplateResult, SVGTemplateResult} from 'lit-html/lit-html';
 import {supportsAdoptingStyleSheets, CSSResult} from './lib/css-tag.js';
 export * from './lib/css-tag.js';
 

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -18,7 +18,7 @@ import {PropertyValues, UpdatingElement} from './lib/updating-element.js';
 
 export * from './lib/updating-element.js';
 export * from './lib/decorators.js';
-export {html, svg} from 'lit-html/lit-html';
+export {html, svg, TemplateResult} from 'lit-html/lit-html';
 
 export class LitElement extends UpdatingElement {
 


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
This should close #412. In short since `render` returns returns `TemplateResult | void` since #316 was merged, it is impossible to add a type definition other than `any` to the return type of `render()` method unless you have `lit-html` installed as well. This PR aims to solve this problem by exporting `TemplateResult` along side `html, svg`. 