### PR TITLE
Removes wrapping of properties in favor of always respecting `noAccessor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fix jsfiddle reference.
 
 ### Changed
-* [Breaking] Property accessors are no longer wrapped when they already exist. Instead the `noAccessor` flag should be set when a user defined accessor is created. ([#450](https://github.com/Polymer/lit-element/issues/450)).
+* [Breaking] Property accessors are no longer wrapped when they already exist. Instead the `noAccessor` flag should be set when a user-defined accessor exists on the prototype (and in this case, user-defined accessors must call `requestUpdate` themselves). ([#450](https://github.com/Polymer/lit-element/issues/450)).
 
 ## [2.0.0-rc.2] - 2019-01-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Fix jsfiddle reference.
 
+### Changed
+* [Breaking] Property accessors are no longer wrapped when they already exist. Instead the `noAccessor` flag should be set when a user defined accessor is created. ([#450](https://github.com/Polymer/lit-element/issues/450)).
+
 ## [2.0.0-rc.2] - 2019-01-11
 ### Fixed
 * Fix references to `@polymer/lit-element` in README and docs ([#427](https://github.com/Polymer/lit-element/pull/427)).

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -102,33 +102,33 @@ const standardProperty =
             clazz.createProperty(element.key, options);
           }
         };
+      } else {
         // createProperty() takes care of defining the property, but we still
         // must return some kind of descriptor, so return a descriptor for an
         // unused prototype field. The finisher calls createProperty().
-      } else {
-      return {
-        kind : 'field',
-        key : Symbol(),
-        placement : 'own',
-        descriptor : {},
-        // When @babel/plugin-proposal-decorators implements initializers,
-        // do this instead of the initializer below. See:
-        // https://github.com/babel/babel/issues/9260 extras: [
-        //   {
-        //     kind: 'initializer',
-        //     placement: 'own',
-        //     initializer: descriptor.initializer,
-        //   }
-        // ],
-        initializer(this: any) {
-          if (typeof element.initializer === 'function') {
-            this[element.key] = element.initializer!.call(this);
+        return {
+          kind : 'field',
+          key : Symbol(),
+          placement : 'own',
+          descriptor : {},
+          // When @babel/plugin-proposal-decorators implements initializers,
+          // do this instead of the initializer below. See:
+          // https://github.com/babel/babel/issues/9260 extras: [
+          //   {
+          //     kind: 'initializer',
+          //     placement: 'own',
+          //     initializer: descriptor.initializer,
+          //   }
+          // ],
+          initializer(this: any) {
+            if (typeof element.initializer === 'function') {
+              this[element.key] = element.initializer!.call(this);
+            }
+          },
+          finisher(clazz: typeof UpdatingElement) {
+            clazz.createProperty(element.key, options);
           }
-        },
-        finisher(clazz: typeof UpdatingElement) {
-          clazz.createProperty(element.key, options);
-        }
-      };
+        };
       }
     };
 

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -275,7 +275,7 @@ export abstract class UpdatingElement extends HTMLElement {
     // Instead, we expect users to call `requestUpdate` themselves from
     // user-defined accessors. Note that if the super has an accessor we will
     // still overwrite it
-    if (!options.noAccessor && !this.prototype.hasOwnProperty(name)) {
+    if (options.noAccessor || this.prototype.hasOwnProperty(name)) {
       return;
     }
     const key = typeof name === 'symbol' ? Symbol() : `__${name}`;

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -276,19 +276,20 @@ export abstract class UpdatingElement extends HTMLElement {
     // user-defined accessors. Note that if the super has an accessor we will
     // still overwrite it
     if (!options.noAccessor && !this.prototype.hasOwnProperty(name)) {
-        const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
-      const desc = {
-        get(): any { return (this as any)[key]; },
-        set(this: UpdatingElement, value: any) {
-          const oldValue = (this as any)[name];
-          (this as any)[key] = value;
-            this.requestUpdate(name, oldValue);
-          },
-          configurable : true,
-          enumerable : true
-        };
-      Object.defineProperty(this.prototype, name, desc);
+      return;
     }
+    const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
+    Object.defineProperty(this.prototype, name, {
+      get(): any { return (this as any)[key]; },
+      set(this: UpdatingElement, value: any) {
+        const oldValue = (this as any)[name];
+        (this as any)[key] = value;
+          this.requestUpdate(name, oldValue);
+        },
+        configurable : true,
+        enumerable : true
+      }
+    );
   }
 
   /**

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -270,7 +270,7 @@ export abstract class UpdatingElement extends HTMLElement {
     // metadata.
     this._ensureClassProperties();
     this._classProperties!.set(name, options);
-    if (!options.noAccessor) {
+    if (!options.noAccessor && !this.prototype.hasOwnProperty(name)) {
         const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
       const desc = {
         get(): any { return (this as any)[key]; },

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -270,6 +270,11 @@ export abstract class UpdatingElement extends HTMLElement {
     // metadata.
     this._ensureClassProperties();
     this._classProperties!.set(name, options);
+    // Do not generate an accessor if the prototype already has one, since
+    // it would be lost otherwise and that would never be the user's intention;
+    // Instead, we expect users to call `requestUpdate` themselves from
+    // user-defined accessors. Note that if the super has an accessor we will
+    // still overwrite it
     if (!options.noAccessor && !this.prototype.hasOwnProperty(name)) {
         const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
       const desc = {

--- a/src/test/lib/decorators_test.ts
+++ b/src/test/lib/decorators_test.ts
@@ -185,6 +185,39 @@ suite('decorators', () => {
       assert.equal(el.updateCount, 6);
     });
 
+    test('can decorate user accessor with @property', async () => {
+      class E extends LitElement {
+
+        _foo?: number;
+        updatedContent?: number;
+
+        @property({reflect : true, type: Number})
+        get foo() {
+          return this._foo as number;
+        }
+
+        set foo(v: number) {
+          const old = this.foo;
+          this._foo = v;
+          this.requestUpdate('foo', old);
+        }
+
+        updated() { this.updatedContent = this.foo; }
+      }
+      customElements.define(generateElementName(), E);
+      const el = new E();
+      container.appendChild(el);
+      await el.updateComplete;
+      assert.equal(el._foo, undefined);
+      assert.equal(el.updatedContent, undefined);
+      assert.isFalse(el.hasAttribute('foo'));
+      el.foo = 5;
+      await el.updateComplete;
+      assert.equal(el._foo, 5);
+      assert.equal(el.updatedContent, 5);
+      assert.equal(el.getAttribute('foo'), '5');
+    });
+
     test('can mix property options via decorator and via getter', async () => {
       const hasChanged = (value: any, old: any) =>
           old === undefined || value > old;

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -2047,13 +2047,16 @@ suite('UpdatingElement', () => {
   });
 
   test('can override performUpdate()', async () => {
+
+    let resolve: (() => void)|undefined;
+
     class A extends UpdatingElement {
       performUpdateCalled = false;
       updateCalled = false;
 
       async performUpdate() {
         this.performUpdateCalled = true;
-        await new Promise((r) => setTimeout(r, 10));
+        await new Promise((r) => resolve = r);
         await super.performUpdate();
       }
 
@@ -2074,12 +2077,13 @@ suite('UpdatingElement', () => {
     await 0;
     assert.isFalse(a.updateCalled);
 
-    // update is not called after short timeout
-    await new Promise((r) => setTimeout(r));
+    // update is not called after a small amount of time
+    await new Promise((r) => setTimeout(r, 10));
     assert.isFalse(a.updateCalled);
 
-    // update is called after long timeout
-    await new Promise((r) => setTimeout(r, 20));
+    // update is called after performUpdate allowed to complete
+    resolve!();
+    await a.updateComplete;
     assert.isTrue(a.updateCalled);
   });
 

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1499,6 +1499,73 @@ suite('UpdatingElement', () => {
     assert.equal(el.getAttribute('id'), 'id2');
   });
 
+  test('user accessors', async () => {
+    class E extends UpdatingElement {
+      _updateCount = 0;
+      updatedText = '';
+      _foo?: String;
+      _bar?: String;
+      static get properties() {
+        return {
+          foo : {type : String, reflect : true},
+          bar : {type : String, reflect : true}
+        };
+      }
+      constructor() {
+        super();
+        this.foo = 'defaultFoo';
+        this.bar = 'defaultBar';
+      }
+      set foo(value: string) {
+        const old = this._foo;
+        this._foo = value;
+        this.requestUpdate('foo', old);
+      }
+      get foo() { return this._foo as string; }
+      set bar(value: string) {
+        const old = this._bar;
+        this._bar = value;
+        this.requestUpdate('bar', old);
+      }
+      get bar() { return this._bar as string; }
+      update(changedProperties: PropertyValues) {
+        this._updateCount++;
+        super.update(changedProperties);
+      }
+      updated() { this.updatedText = `${this.foo}-${this.bar}`; }
+    }
+    customElements.define(generateElementName(), E);
+
+    const el = new E();
+    el.foo = 'foo1';
+    document.body.appendChild(el);
+    await el.updateComplete;
+    assert.equal(el.foo, 'foo1');
+    assert.equal(el.bar, 'defaultBar');
+    assert.equal(el.getAttribute('foo'), 'foo1');
+    assert.equal(el.getAttribute('bar'), 'defaultBar');
+    assert.equal(el.updatedText, 'foo1-defaultBar');
+    assert.equal(el._updateCount, 1);
+
+    el.foo = 'foo2';
+    el.bar = 'bar';
+    await el.updateComplete;
+    assert.equal(el.foo, 'foo2');
+    assert.equal(el.bar, 'bar');
+    assert.equal(el.getAttribute('foo'), 'foo2');
+    assert.equal(el.getAttribute('bar'), 'bar');
+    assert.equal(el.updatedText, 'foo2-bar');
+    assert.equal(el._updateCount, 2);
+
+    el.foo = 'foo3';
+    await el.updateComplete;
+    assert.equal(el.foo, 'foo3');
+    assert.equal(el.getAttribute('foo'), 'foo3');
+    assert.equal(el.getAttribute('bar'), 'bar');
+    assert.equal(el.updatedText, 'foo3-bar');
+    assert.equal(el._updateCount, 3);
+  });
+
   test('user accessors can be extended', async () => {
     // Sup implements an accessor that clamps to a maximum in the setter
     class Sup extends UpdatingElement {
@@ -1506,7 +1573,7 @@ suite('UpdatingElement', () => {
       _oldFoo?: any;
       _foo?: number;
       updatedText = '';
-      static get properties() { return {foo : {type : Number, noAccessor: true}}; }
+      static get properties() { return {foo : {type : Number}}; }
       constructor() {
         super();
         this.foo = 0;
@@ -1529,7 +1596,7 @@ suite('UpdatingElement', () => {
     // Sub implements an accessor that rounds down in the getter
     class Sub extends Sup {
       _subSetCount?: number;
-      static get properties() { return {foo : {type : Number, noAccessor: true}}; }
+      static get properties() { return {foo : {type : Number}}; }
       set foo(v: number) {
         this._subSetCount = (this._subSetCount || 0) + 1;
         super.foo = v;
@@ -1604,83 +1671,75 @@ suite('UpdatingElement', () => {
     assert.equal(sub.updatedText, '10');
   });
 
-  test('user accessors only using noAccessor', async () => {
-    class E extends UpdatingElement {
-      _updateCount = 0;
-      updatedText = '';
-      _foo?: String;
-      _bar?: String;
-      static get properties() {
-        return {
-          foo : {type : String, reflect : true, noAccessor : true},
-          bar : {type : String, reflect : true, noAccessor : true}
-        };
-      }
-      constructor() {
-        super();
-        this.foo = 'defaultFoo';
-        this.bar = 'defaultBar';
-      }
-      set foo(value: string) {
-        const old = this._foo;
-        this._foo = value;
-        this.requestUpdate('foo', old);
-      }
-      get foo() { return this._foo as string; }
-      set bar(value: string) {
-        const old = this._bar;
-        this._bar = value;
-        this.requestUpdate('bar', old);
-      }
-      get bar() { return this._bar as string; }
-      update(changedProperties: PropertyValues) {
-        this._updateCount++;
-        super.update(changedProperties);
-      }
-      updated() { this.updatedText = `${this.foo}-${this.bar}`; }
-    }
-    customElements.define(generateElementName(), E);
+  test('Using `noAccessor` to set property options for extended user accessors',
+       async () => {
+         // Sup implements an accessor that clamps to a maximum in the setter
+         class Sup extends UpdatingElement {
+           _supSetCount?: number;
+           _oldFoo?: any;
+           _foo?: number;
+           updatedText = '';
+           static get properties() { return {foo : {type : Number}}; }
+           constructor() {
+             super();
+             this.foo = 0;
+           }
+           set foo(v: number) {
+             this._supSetCount = (this._supSetCount || 0) + 1;
+             const old = this.foo;
+             this._foo = Math.min(v, 10);
+             this.requestUpdate('foo', old);
+           }
+           get foo(): number { return this._foo as number; }
+           update(changedProperties: PropertyValues) {
+             this._oldFoo = changedProperties.get('foo');
+             super.update(changedProperties);
+           }
+           updated() { this.updatedText = `${this.foo}`; }
+         }
+         customElements.define(generateElementName(), Sup);
 
-    const el = new E();
-    el.foo = 'foo1';
-    document.body.appendChild(el);
-    await el.updateComplete;
-    assert.equal(el.foo, 'foo1');
-    assert.equal(el.bar, 'defaultBar');
-    assert.equal(el.getAttribute('foo'), 'foo1');
-    assert.equal(el.getAttribute('bar'), 'defaultBar');
-    assert.equal(el.updatedText, 'foo1-defaultBar');
-    assert.equal(el._updateCount, 1);
+         // Sub implements an accessor that rounds down in the getter
+         class Sub extends Sup {
+           static get properties() {
+             return {foo : {type : Number, reflect : true, noAccessor : true}};
+           }
+         }
+         customElements.define(generateElementName(), Sub);
 
-    el.foo = 'foo2';
-    el.bar = 'bar';
-    await el.updateComplete;
-    assert.equal(el.foo, 'foo2');
-    assert.equal(el.bar, 'bar');
-    assert.equal(el.getAttribute('foo'), 'foo2');
-    assert.equal(el.getAttribute('bar'), 'bar');
-    assert.equal(el.updatedText, 'foo2-bar');
-    assert.equal(el._updateCount, 2);
+         const sub = new Sub();
+         container.appendChild(sub);
+         await sub.updateComplete;
+         assert.equal(sub.foo, 0);
+         assert.equal(sub._oldFoo, undefined);
+         assert.equal(sub._supSetCount, 1);
+         assert.equal(sub.updatedText, '0');
 
-    el.foo = 'foo3';
-    await el.updateComplete;
-    assert.equal(el.foo, 'foo3');
-    assert.equal(el.getAttribute('foo'), 'foo3');
-    assert.equal(el.getAttribute('bar'), 'bar');
-    assert.equal(el.updatedText, 'foo3-bar');
-    assert.equal(el._updateCount, 3);
-  });
+         sub.foo = 5;
+         await sub.updateComplete;
+         assert.equal(sub.foo, 5);
+         assert.equal(sub._oldFoo, 0);
+         assert.equal(sub._supSetCount, 2);
+         assert.equal(sub.updatedText, '5');
+         assert.equal(sub.getAttribute('foo'), '5');
+       });
 
   test('attribute-based property storage', async () => {
     class E extends UpdatingElement {
       _updateCount = 0;
       updatedText = '';
       static get properties() {
-        return {foo : {type : String, noAccessor: true}, bar : {type : String, noAccessor: true}};
+        return {foo : {type : String}, bar : {type : String}};
       }
-      set foo(value: string|null) { this.setAttribute('foo', value as string); this.requestUpdate(); }
+      set foo(value: string|null) {
+        this.setAttribute('foo', value as string);
+        this.requestUpdate();
+      }
       get foo() { return this.getAttribute('foo') || 'defaultFoo'; }
-      set bar(value: string|null) { this.setAttribute('bar', value as string); this.requestUpdate(); }
+      set bar(value: string|null) {
+        this.setAttribute('bar', value as string);
+        this.requestUpdate();
+      }
       get bar() { return this.getAttribute('bar') || 'defaultBar'; }
       update(changedProperties: PropertyValues) {
         this._updateCount++;
@@ -1723,10 +1782,7 @@ suite('UpdatingElement', () => {
       _updateCount = 0;
       updatedText = '';
       static get properties() {
-        return {
-          foo : {type : String, noAccessor : true},
-          bar : {type : String, noAccessor : true}
-        };
+        return {foo : {type : String}, bar : {type : String}};
       }
       set foo(value: string|null) { this.setAttribute('foo', value as string); }
       get foo() { return this.getAttribute('foo') || 'defaultFoo'; }

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1499,21 +1499,23 @@ suite('UpdatingElement', () => {
     assert.equal(el.getAttribute('id'), 'id2');
   });
 
-  test('user accessors correctly wrapped', async () => {
+  test('user accessors can be extended', async () => {
     // Sup implements an accessor that clamps to a maximum in the setter
     class Sup extends UpdatingElement {
       _supSetCount?: number;
       _oldFoo?: any;
       _foo?: number;
       updatedText = '';
-      static get properties() { return {foo : {type : Number}}; }
+      static get properties() { return {foo : {type : Number, noAccessor: true}}; }
       constructor() {
         super();
         this.foo = 0;
       }
       set foo(v: number) {
         this._supSetCount = (this._supSetCount || 0) + 1;
+        const old = this.foo;
         this._foo = Math.min(v, 10);
+        this.requestUpdate('foo', old);
       }
       get foo(): number { return this._foo as number; }
       update(changedProperties: PropertyValues) {
@@ -1527,7 +1529,7 @@ suite('UpdatingElement', () => {
     // Sub implements an accessor that rounds down in the getter
     class Sub extends Sup {
       _subSetCount?: number;
-      static get properties() { return {foo : {type : Number}}; }
+      static get properties() { return {foo : {type : Number, noAccessor: true}}; }
       set foo(v: number) {
         this._subSetCount = (this._subSetCount || 0) + 1;
         super.foo = v;
@@ -1674,11 +1676,11 @@ suite('UpdatingElement', () => {
       _updateCount = 0;
       updatedText = '';
       static get properties() {
-        return {foo : {type : String}, bar : {type : String}};
+        return {foo : {type : String, noAccessor: true}, bar : {type : String, noAccessor: true}};
       }
-      set foo(value: string|null) { this.setAttribute('foo', value as string); }
+      set foo(value: string|null) { this.setAttribute('foo', value as string); this.requestUpdate(); }
       get foo() { return this.getAttribute('foo') || 'defaultFoo'; }
-      set bar(value: string|null) { this.setAttribute('bar', value as string); }
+      set bar(value: string|null) { this.setAttribute('bar', value as string); this.requestUpdate(); }
       get bar() { return this.getAttribute('bar') || 'defaultBar'; }
       update(changedProperties: PropertyValues) {
         this._updateCount++;


### PR DESCRIPTION
Fixes #450. This removes all wrapping of existing accessors. This changes makes property generation simpler and more straightforward. If an accessor should not be generated, for example when there is a user defined accessor, users should set the `noAccessor` flag to true.