### PR TITLE
Replace use of for/of loops over Maps with forEach.

### DIFF
--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -133,9 +133,10 @@ const legacyProperty = (options: PropertyDeclaration, proto: Object,
  */
 export function property(options?: PropertyDeclaration) {
   return (protoOrDescriptor: Object|ClassElement, name?: PropertyKey): any =>
-             (name !== undefined) ?
-      legacyProperty(options!, protoOrDescriptor as Object, name) :
-      standardProperty(options!, protoOrDescriptor as ClassElement);
+             (name !== undefined)
+                 ? legacyProperty(options!, protoOrDescriptor as Object, name)
+                 : standardProperty(options!,
+                                    protoOrDescriptor as ClassElement);
 }
 
 /**


### PR DESCRIPTION
This makes the code safe against being compiled with non-spec-compliant for/of, which will usually expect an array. Previously properties would silently not work when compiled with Babel on many online code editor platforms.