### PR TITLE
Removes default for `static get styles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.0-rc.2] - 2019-01-11
 ### Fixed
+* Class fields can now be used to define styles, e.g. `static styles = css` and styles correctly compose when elements are extended ([#456](https://github.com/Polymer/lit-element/pull/456)).
 * Fix references to `@polymer/lit-element` in README and docs ([#427](https://github.com/Polymer/lit-element/pull/427)).
 * Fix decorator types causing compiler errors for TypeScript users. ([#431](https://github.com/Polymer/lit-element/pull/431)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.0-rc.2] - 2019-01-11
 ### Fixed
-* Class fields can now be used to define styles, e.g. `static styles = css` and styles correctly compose when elements are extended ([#456](https://github.com/Polymer/lit-element/pull/456)).
+* Class fields can now be used to define styles, e.g. `static styles = css` and `styles` correctly compose when elements are extended ([#456](https://github.com/Polymer/lit-element/pull/456)).
 * Fix references to `@polymer/lit-element` in README and docs ([#427](https://github.com/Polymer/lit-element/pull/427)).
 * Fix decorator types causing compiler errors for TypeScript users. ([#431](https://github.com/Polymer/lit-element/pull/431)).
 

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -18,7 +18,7 @@
  * alias this function, so we have to use a small shim that has the same
  * behavior when not compiling.
  */
-const JSCompiler_renameProperty = (prop: PropertyKey, _obj: any) => prop;
+export const JSCompiler_renameProperty = (prop: PropertyKey, _obj: any) => prop;
 
 /**
  * Returns the property descriptor for a property on this prototype by walking

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -66,14 +66,15 @@ export class LitElement extends UpdatingElement {
    * Array of styles to apply to the element. The styles should be defined
    * using the `css` tag function.
    */
-  static get styles(): CSSResult | CSSResultArray { return []; }
+  static styles?: CSSResult | CSSResultArray;
 
   private static _styles: CSSResult[]|undefined;
 
   private static get _uniqueStyles(): CSSResult[] {
     if (this._styles === undefined) {
-      if (Array.isArray(this.styles)) {
-        const styles = flattenStyles(this.styles);
+      const userStyles = this.styles;
+      if (Array.isArray(userStyles)) {
+        const styles = flattenStyles(userStyles);
         // As a performance optimization to avoid duplicated styling that can
         // occur especially when composing via subclassing, de-duplicate styles
         // preserving the last item in the list. The last item is kept to
@@ -88,7 +89,7 @@ export class LitElement extends UpdatingElement {
         this._styles = [];
         styleSet.forEach((v) => this._styles!.unshift(v));
       } else {
-        this._styles = [this.styles];
+        this._styles = userStyles ? [userStyles] : [];
       }
     }
     return this._styles;

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -14,7 +14,7 @@
 import {TemplateResult} from 'lit-html';
 import {render} from 'lit-html/lib/shady-render';
 
-import {PropertyValues, UpdatingElement} from './lib/updating-element.js';
+import {PropertyValues, UpdatingElement, JSCompiler_renameProperty} from './lib/updating-element.js';
 
 export * from './lib/updating-element.js';
 export * from './lib/decorators.js';
@@ -71,28 +71,39 @@ export class LitElement extends UpdatingElement {
   private static _styles: CSSResult[]|undefined;
 
   private static get _uniqueStyles(): CSSResult[] {
-    if (this._styles === undefined) {
-      const userStyles = this.styles;
-      if (Array.isArray(userStyles)) {
-        const styles = flattenStyles(userStyles);
-        // As a performance optimization to avoid duplicated styling that can
-        // occur especially when composing via subclassing, de-duplicate styles
-        // preserving the last item in the list. The last item is kept to
-        // try to preserve cascade order with the assumption that it's most
-        // important that last added styles override previous styles.
-        const styleSet = styles.reduceRight((set, s) => {
-          set.add(s);
-          // on IE set.add does not return the set.
-          return set;
-        }, new Set<CSSResult>());
-        // Array.from does not work on Set in IE
-        this._styles = [];
-        styleSet.forEach((v) => this._styles!.unshift(v));
+    if (!this.hasOwnProperty(JSCompiler_renameProperty('_styles', this))) {
+      // Inherit styles from superclass if none have been set.
+      if (!this.hasOwnProperty(JSCompiler_renameProperty('styles', this))) {
+        this._styles = this._styles !== undefined ? this._styles : [];
       } else {
-        this._styles = userStyles ? [userStyles] : [];
+        // Take care not to call `this.styles` multiple times since this generates
+        // new CSSResults each time.
+        // TODO(sorvell): Since we do not cache CSSResults by input, any
+        // shared styles will generate new stylesheet objects, which is wasteful.
+        // This should be addressed when a browser ships constructable
+        // stylesheets.
+        const userStyles = this.styles;
+        if (Array.isArray(userStyles)) {
+          const styles = flattenStyles(userStyles);
+          // As a performance optimization to avoid duplicated styling that can
+          // occur especially when composing via subclassing, de-duplicate styles
+          // preserving the last item in the list. The last item is kept to
+          // try to preserve cascade order with the assumption that it's most
+          // important that last added styles override previous styles.
+          const styleSet = styles.reduceRight((set, s) => {
+            set.add(s);
+            // on IE set.add does not return the set.
+            return set;
+          }, new Set<CSSResult>());
+          // Array.from does not work on Set in IE
+          this._styles = [];
+          styleSet.forEach((v) => this._styles!.unshift(v));
+        } else {
+          this._styles = userStyles ? [userStyles] : [];
+        }
       }
     }
-    return this._styles;
+    return this._styles as CSSResult[];
   }
 
   private _needsShimAdoptedStyleSheets?: boolean;

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -570,6 +570,126 @@ suite('Static get styles', () => {
     assert.equal(getComputedStyleValue(span!, 'border-top-width').trim(),
                  '3px');
   });
+
+  test('can extend and augment `styles`', async () => {
+    const base = generateElementName();
+    customElements.define(base, class extends LitElement {
+      static get styles() { return css`div {
+          border: 2px solid blue;
+        }`;
+      }
+
+      render() {
+        return htmlWithStyles`
+        <div>Testing1</div>`;
+      }
+    });
+
+    const sub = generateElementName();
+    customElements.define(sub, class extends customElements.get(base) {
+      static get styles() {
+        return [
+          super.styles,
+          css`span {
+            display: block;
+            border: 3px solid blue;
+          }`
+        ];
+      }
+
+      render() {
+        return htmlWithStyles`
+        ${super.render()}
+        <span>Testing2</span>`;
+      }
+    });
+
+    const subsub = generateElementName();
+    customElements.define(subsub, class extends customElements.get(sub) {
+      static get styles() {
+        return [
+          super.styles,
+          css`p {
+            display: block;
+            border: 4px solid blue;
+          }`
+        ];
+      }
+
+      render() {
+        return htmlWithStyles`
+        ${super.render()}
+        <p>Testing3</p>`;
+      }
+    });
+    let el = document.createElement(base);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    const div = el.shadowRoot!.querySelector('div');
+    assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(), '2px');
+    el = document.createElement(sub);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    const span = el.shadowRoot!.querySelector('span');
+    assert.equal(getComputedStyleValue(span!, 'border-top-width').trim(),
+                 '3px');
+    el = document.createElement(subsub);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    const p = el.shadowRoot!.querySelector('p');
+    assert.equal(getComputedStyleValue(p!, 'border-top-width').trim(),
+                 '4px');
+  });
+
+  test('can extend and override `styles`', async () => {
+    const base = generateElementName();
+    customElements.define(base, class extends LitElement {
+      static get styles() { return css`div {
+          border: 2px solid blue;
+        }`;
+      }
+
+      render() {
+        return htmlWithStyles`
+        <div>Testing1</div>`;
+      }
+    });
+
+    const sub = generateElementName();
+    customElements.define(sub, class extends customElements.get(base) {
+      static get styles() { return css`div {
+          border: 3px solid blue;
+        }`;
+      }
+
+    });
+
+    const subsub = generateElementName();
+    customElements.define(subsub, class extends customElements.get(sub) {
+      static get styles() { return css`div {
+          border: 4px solid blue;
+        }`;
+      }
+
+    });
+    let el = document.createElement(base);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    let div = el.shadowRoot!.querySelector('div');
+    assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(), '2px');
+    el = document.createElement(sub);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    div = el.shadowRoot!.querySelector('div');
+    assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(),
+                 '3px');
+    el = document.createElement(subsub);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    div = el.shadowRoot!.querySelector('div');
+    assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(),
+                 '4px');
+  });
 });
 
 suite('ShadyDOM', () => {

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -541,6 +541,35 @@ suite('Static get styles', () => {
     assert.equal(getComputedStyleValue(level3!, 'border-top-width').trim(), '3px');
     assert.equal(getComputedStyleValue(level4!, 'border-top-width').trim(), '4px');
   });
+
+  test('`styles` can be a static field', async () => {
+    const name = generateElementName();
+    customElements.define(name, class extends LitElement {
+      static styles = [
+        css`div {
+          border: 2px solid blue;
+        }`,
+        css`span {
+          display: block;
+          border: 3px solid blue;
+        }`
+      ];
+
+      render() {
+        return htmlWithStyles`
+        <div>Testing1</div>
+        <span>Testing2</span>`;
+      }
+    });
+    const el = document.createElement(name);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    const div = el.shadowRoot!.querySelector('div');
+    assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(), '2px');
+    const span = el.shadowRoot!.querySelector('span');
+    assert.equal(getComputedStyleValue(span!, 'border-top-width').trim(),
+                 '3px');
+  });
 });
 
 suite('ShadyDOM', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2017",
     "module": "es2015",
     "moduleResolution": "node",
-    "lib": ["es2017", "dom", "esnext"],
+    "lib": ["esnext.array", "esnext", "es2017", "dom"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Fixes #452.

In addition...
* Fixes type settings so `Array.flat` works.
* Optimization: ensures `this.styles` is accessed only once per definition. Since this getter generates CSSResults, it should not be run superfluously.