### PR TITLE
Remove almost all uses of `any`.

### DIFF
--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -18,7 +18,7 @@ import {LitElement} from '../lit-element.js';
 import {PropertyDeclaration, UpdatingElement} from './updating-element.js';
 
 export type Constructor<T> = {
-  new (...args: any[]): T
+  new (...args: unknown[]): T
 };
 
 // From the TC39 Decorators proposal
@@ -47,6 +47,7 @@ const legacyCustomElement =
       // `Constructor<HTMLElement>` for some reason.
       // `Constructor<HTMLElement>` is helpful to make sure the decorator is
       // applied to elements however.
+      // tslint:disable-next-line:no-any
       return clazz as any;
     };
 
@@ -106,6 +107,7 @@ const standardProperty =
           //     initializer: descriptor.initializer,
           //   }
           // ],
+          // tslint:disable-next-line:no-any decorator
           initializer(this: any) {
             if (typeof element.initializer === 'function') {
               this[element.key] = element.initializer!.call(this);
@@ -132,6 +134,7 @@ const legacyProperty =
  * @ExportDecoratedItems
  */
 export function property(options?: PropertyDeclaration) {
+  // tslint:disable-next-line:no-any decorator
   return (protoOrDescriptor: Object|ClassElement, name?: PropertyKey): any =>
              (name !== undefined) ?
       legacyProperty(options!, protoOrDescriptor as Object, name) :
@@ -177,6 +180,7 @@ const standardQuery = (descriptor: PropertyDescriptor, element: ClassElement) =>
 function _query<T>(queryFn: (target: NodeSelector, selector: string) => T) {
   return (selector: string) =>
              (protoOrDescriptor: Object|ClassElement,
+              // tslint:disable-next-line:no-any decorator
               name?: PropertyKey): any => {
                const descriptor = {
                  get(this: LitElement) {
@@ -203,6 +207,7 @@ const standardEventOptions =
     };
 
 const legacyEventOptions =
+    // tslint:disable-next-line:no-any legacy decorator
     (options: AddEventListenerOptions, proto: any, name: PropertyKey) => {
       Object.assign(proto[name], options);
     };
@@ -243,4 +248,5 @@ export const eventOptions = (options: AddEventListenerOptions) =>
          (name !== undefined) ?
          legacyEventOptions(options, protoOrDescriptor as Object, name) :
          standardEventOptions(options, protoOrDescriptor as ClassElement)) as
-    any;
+        // tslint:disable-next-line:no-any decorator
+        any;

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -38,13 +38,16 @@ export interface ComplexAttributeConverter<Type = unknown, TypeHint = unknown> {
    * Function called to convert an attribute value to a property
    * value.
    */
-  fromAttribute?(value: string, type?: TypeHint): Type;
+  fromAttribute?(value: string|null, type?: TypeHint): Type;
 
   /**
    * Function called to convert a property value to an attribute
    * value.
+   *
+   * It returns unknown instead of string, to be compatible with
+   * https://github.com/WICG/trusted-types (and similar efforts).
    */
-  toAttribute?(value: Type, type?: TypeHint): string|null;
+  toAttribute?(value: Type, type?: TypeHint): unknown;
 }
 
 type AttributeConverter<Type = unknown, TypeHint = unknown> =
@@ -128,28 +131,28 @@ export type PropertyValues = Map<PropertyKey, unknown>;
 
 export const defaultConverter: ComplexAttributeConverter = {
 
-  toAttribute(value: unknown, type?: unknown): string | null {
+  toAttribute(value: unknown, type?: unknown): unknown {
     switch (type) {
-      case Boolean:
-        return value ? '' : null;
-      case Object:
-      case Array:
-        // if the value is `null` or `undefined` pass this through
-        // to allow removing/no change behavior.
-        return value == null ? (value as null) : JSON.stringify(value);
+    case Boolean:
+      return value ? '' : null;
+    case Object:
+    case Array:
+      // if the value is `null` or `undefined` pass this through
+      // to allow removing/no change behavior.
+      return value == null ? value : JSON.stringify(value);
     }
-    return value as string | null;
+    return value;
   },
 
-  fromAttribute(value: unknown, type?: unknown) {
+  fromAttribute(value: string|null, type?: unknown) {
     switch (type) {
-      case Boolean:
-        return value !== null;
-      case Number:
-        return value === null ? null : Number(value);
-      case Object:
-      case Array:
-        return JSON.parse(value as string);
+    case Boolean:
+      return value !== null;
+    case Number:
+      return value === null ? null : Number(value);
+    case Object:
+    case Array:
+      return JSON.parse(value!);
     }
     return value;
   }
@@ -381,8 +384,8 @@ export abstract class UpdatingElement extends HTMLElement {
    * `converter` or `converter.fromAttribute` property option.
    * @nocollapse
    */
-  private static _propertyValueFromAttribute(
-      value: string, options: PropertyDeclaration) {
+  private static _propertyValueFromAttribute(value: string|null,
+                                             options: PropertyDeclaration) {
     const type = options.type;
     const converter = options.converter || defaultConverter;
     const fromAttribute =
@@ -505,7 +508,7 @@ export abstract class UpdatingElement extends HTMLElement {
   /**
    * Synchronizes property values when attributes change.
    */
-  attributeChangedCallback(name: string, old: string, value: string) {
+  attributeChangedCallback(name: string, old: string|null, value: string|null) {
     if (old !== value) {
       this._attributeToProperty(name, value);
     }
@@ -534,14 +537,14 @@ export abstract class UpdatingElement extends HTMLElement {
       if (attrValue == null) {
         this.removeAttribute(attr);
       } else {
-        this.setAttribute(attr, attrValue);
+        this.setAttribute(attr, attrValue as string);
       }
       // mark state not reflecting
       this._updateState = this._updateState & ~STATE_IS_REFLECTING_TO_ATTRIBUTE;
     }
   }
 
-  private _attributeToProperty(name: string, value: string) {
+  private _attributeToProperty(name: string, value: string|null) {
     // Use tracking info to avoid deserializing attribute value if it was
     // just set from a property setter.
     if (this._updateState & STATE_IS_REFLECTING_TO_ATTRIBUTE) {

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -133,26 +133,26 @@ export const defaultConverter: ComplexAttributeConverter = {
 
   toAttribute(value: unknown, type?: unknown): unknown {
     switch (type) {
-    case Boolean:
-      return value ? '' : null;
-    case Object:
-    case Array:
-      // if the value is `null` or `undefined` pass this through
-      // to allow removing/no change behavior.
-      return value == null ? value : JSON.stringify(value);
+      case Boolean:
+        return value ? '' : null;
+      case Object:
+      case Array:
+        // if the value is `null` or `undefined` pass this through
+        // to allow removing/no change behavior.
+        return value == null ? value : JSON.stringify(value);
     }
     return value;
   },
 
   fromAttribute(value: string|null, type?: unknown) {
     switch (type) {
-    case Boolean:
-      return value !== null;
-    case Number:
-      return value === null ? null : Number(value);
-    case Object:
-    case Array:
-      return JSON.parse(value!);
+      case Boolean:
+        return value !== null;
+      case Number:
+        return value === null ? null : Number(value);
+      case Object:
+      case Array:
+        return JSON.parse(value!);
     }
     return value;
   }
@@ -384,8 +384,8 @@ export abstract class UpdatingElement extends HTMLElement {
    * `converter` or `converter.fromAttribute` property option.
    * @nocollapse
    */
-  private static _propertyValueFromAttribute(value: string|null,
-                                             options: PropertyDeclaration) {
+  private static _propertyValueFromAttribute(
+      value: string|null, options: PropertyDeclaration) {
     const type = options.type;
     const converter = options.converter || defaultConverter;
     const fromAttribute =

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -208,7 +208,7 @@ export class LitElement extends UpdatingElement {
    */
   protected update(changedProperties: PropertyValues) {
     super.update(changedProperties);
-    const templateResult = this.render() as any;
+    const templateResult = this.render() as unknown;
     if (templateResult instanceof TemplateResult) {
       (this.constructor as typeof LitElement)
           .render(

--- a/src/test/lib/decorators_test.ts
+++ b/src/test/lib/decorators_test.ts
@@ -16,6 +16,8 @@ import {eventOptions, property} from '../../lib/decorators.js';
 import {customElement, html, LitElement, PropertyValues, query, queryAll} from '../../lit-element.js';
 import {generateElementName} from '../test-helpers.js';
 
+// tslint:disable:no-any ok in tests
+
 let hasOptions;
 const supportsOptions = (function() {
   if (hasOptions !== undefined) {

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -16,6 +16,8 @@ import {property} from '../../lib/decorators.js';
 import {ComplexAttributeConverter, PropertyDeclarations, PropertyValues, UpdatingElement} from '../../lib/updating-element.js';
 import {generateElementName} from '../test-helpers.js';
 
+// tslint:disable:no-any ok in tests
+
 const assert = chai.assert;
 
 suite('UpdatingElement', () => {

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -456,6 +456,7 @@ suite('Static get styles', () => {
 
   test('`css` get styles throws when unsafe values are used', async () => {
     assert.throws(() => {
+      // tslint:disable:no-any intentionally unsafe code
       css`div { border: ${`2px solid blue;` as any}}`;
     });
   });

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -18,6 +18,8 @@ import {generateElementName, stripExpressionDelimeters} from './test-helpers.js'
 
 const assert = chai.assert;
 
+// tslint:disable:no-any ok in tests
+
 suite('LitElement', () => {
   let container: HTMLElement;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
     "outDir": "./",
     // Only necessary because @types/uglify-js can't find types for source-map
     "skipLibCheck": true,

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
       "spaces"
     ],
     "prefer-const": true,
+    "no-any": true,
     "no-duplicate-variable": true,
     "no-eval": true,
     "no-internal-module": true,


### PR DESCRIPTION
Also marks any properties that seem readonly as `readonly`. Likewise `ReadonlyArray`.