### PR TITLE
Fix documentation of :host and :host() pseudo-classes

### DIFF
--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -12,9 +12,14 @@ slug: styles
 * ToC
 {:toc}
 
-## Use the :host CSS pseudo-class 
+## Use the :host and :host() CSS pseudo-classes
 
-In a style block, use the `:host` CSS pseudo-class to select the host element:
+When styling your custom element, you can use the `:host` and `:host()` CSS pseudo-classes in a `<style>` block to select the host element (the element hosting the root of your shadow DOM). The two pseudo-classes slightly differ in usage:
+
+* Use `:host(...)` when you need to apply a CSS selector (e.g. a class or attribute selector).
+* Use `:host` to refer to the host element, wihout further selection.
+
+Please note, that `:host` and `:host()` (with empty parentheses) do not behave the same. Here's a simple example:
 
 _my-element.js_
 
@@ -23,7 +28,8 @@ render() {
   return html`
     <style>
       :host([hidden]) { display: none; }
-      :host { display: block; 
+      :host {
+        display: block; 
         border: 1px solid black;
       }
     </style>
@@ -34,15 +40,15 @@ render() {
 
 {% include project.html folder="docs/style/hostselector" openFile="my-element.js" %}
 
-See the MDN documentation on [:host](https://developer.mozilla.org/en-US/docs/Web/CSS/:host()) and [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) for more information.
+See the MDN documentation on [:host](https://developer.mozilla.org/en-US/docs/Web/CSS/:host), [:host()](https://developer.mozilla.org/en-US/docs/Web/CSS/:host()), and [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) for more information.
 
-### Set :host display styles
+### Set host element display styles
 
 Two best practices for working with custom elements are:
 
 * Set a `:host` display style such as `block` or `inline-block` so that your component's `width` and `height` can be set.
 
-* Set a `:host` display style that respects the `hidden` attribute.
+* Set a `:host()` display style that respects the `hidden` attribute.
 
 ```html
 <style>

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -22,7 +22,7 @@ _my-element.js_
 render() {
   return html`
     <style>
-      :host[hidden] { display: none; }
+      :host([hidden]) { display: none; }
       :host { display: block; 
         border: 1px solid black;
       }
@@ -46,7 +46,7 @@ Two best practices for working with custom elements are:
 
 ```html
 <style>
-  :host[hidden] { display: none; }
+  :host([hidden]) { display: none; }
   :host { display: block; }
 </style>
 ```
@@ -248,7 +248,7 @@ _my-element.js_
 render() {
   return html`
     <style>
-      :host[hidden] { display: none; }
+      :host([hidden]) { display: none; }
       :host { display: block; 
         color: var(--myColor, aliceblue);
         font-family: var(--myFont, Verdana);

--- a/docs/_includes/projects/docs/style/bestpracs/my-element.js
+++ b/docs/_includes/projects/docs/style/bestpracs/my-element.js
@@ -4,7 +4,7 @@ class MyElement extends LitElement {
   render() {
     return html`
       <style>
-        :host[hidden] { display: none; }
+        :host([hidden]) { display: none; }
         :host { display: block; }
       </style>
       <p>Hello world</p>

--- a/docs/_includes/projects/docs/style/customproperties/my-element.js
+++ b/docs/_includes/projects/docs/style/customproperties/my-element.js
@@ -4,7 +4,7 @@ class MyElement extends LitElement {
   render() {
     return html`
       <style>
-        :host[hidden] { display: none; }
+        :host([hidden]) { display: none; }
         :host { display: block;
           background-color: var(--myBackground, yellow);
           color: var(--myColor, black);

--- a/docs/_includes/projects/docs/style/host/my-element.js
+++ b/docs/_includes/projects/docs/style/host/my-element.js
@@ -4,7 +4,7 @@ class MyElement extends LitElement {
   render() {
     return html`
       <style>
-        :host[hidden] { display: none; }
+        :host([hidden]) { display: none; }
         :host {
           display: block;
           font-family: Roboto;

--- a/docs/_includes/projects/docs/style/hostselector/my-element.js
+++ b/docs/_includes/projects/docs/style/hostselector/my-element.js
@@ -4,7 +4,7 @@ class MyElement extends LitElement {
   render() {
     return html`
       <style>
-        :host[hidden] { display: none; }
+        :host([hidden]) { display: none; }
         :host { display: block;
           border: 1px solid black;
         }

--- a/docs/_includes/projects/docs/style/inherited/my-element.js
+++ b/docs/_includes/projects/docs/style/inherited/my-element.js
@@ -4,7 +4,7 @@ class MyElement extends LitElement {
   render() {
     return html`
       <style>
-        :host[hidden] { display: none; }
+        :host([hidden]) { display: none; }
         :host {
           display: block;
           font-family: Roboto;

--- a/docs/_includes/projects/docs/style/maindocument/my-element.js
+++ b/docs/_includes/projects/docs/style/maindocument/my-element.js
@@ -4,7 +4,7 @@ class MyElement extends LitElement {
   render() {
     return html`
       <style>
-        :host[hidden] { display: none; }
+        :host([hidden]) { display: none; }
         :host {
           display: block;
         }

--- a/docs/_includes/projects/docs/style/slotted/my-element.js
+++ b/docs/_includes/projects/docs/style/slotted/my-element.js
@@ -4,7 +4,7 @@ class MyElement extends LitElement {
   render() {
     return html`
       <style>
-        :host[hidden] { display: none; }
+        :host([hidden]) { display: none; }
         :host { display: block; }
         ::slotted(*) { font-family: Roboto; }
         ::slotted(span) { color: blue; }

--- a/docs/_includes/projects/docs/style/smalltheme/my-element.js
+++ b/docs/_includes/projects/docs/style/smalltheme/my-element.js
@@ -12,7 +12,7 @@ class MyElement extends LitElement {
   render() {
     return html`
       <style>
-        :host[hidden] { display: none; }
+        :host([hidden]) { display: none; }
         :host { display: block;
           color: var(--myColor);
           font-family: var(--myFont);


### PR DESCRIPTION
I had some trouble getting the attribute `hidden` to work, because the examples in the docs are faulty.

* I fixed the code snippets / examples.
* I changed the explanatory introduction text, to point out that there are two pseudo-classes, how they are different, and which one to use when.

### Reference Issue
Fixes part of #353.
