### PR TITLE
Fix closure compiler renaming safety.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
-* Fixed a bug where we broke compatibility with closure compiler's property
-  renaming optimizations. JSCompiler_renameProperty can't be a module export.
+* Fixed a bug where we broke compatibility with closure compiler's property renaming optimizations. JSCompiler_renameProperty can't be a module export ([#465](https://github.com/Polymer/lit-element/pull/465)).
 
 ## [2.0.0-rc.3] - 2019-01-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Changed -->
 <!-- ### Removed -->
 <!-- ### Fixed -->
+## Unreleased
+
+### Fixed
+* Fixed a bug where we broke compatibility with closure compiler's property
+  renaming optimizations. JSCompiler_renameProperty can't be a module export.
 
 ## [2.0.0-rc.3] - 2019-01-18
 ### Fixed

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -18,7 +18,17 @@
  * alias this function, so we have to use a small shim that has the same
  * behavior when not compiling.
  */
-export const JSCompiler_renameProperty = (prop: PropertyKey, _obj: any) => prop;
+window.JSCompiler_renameProperty =
+    <P extends PropertyKey>(prop: P, _obj: unknown): P => prop;
+
+declare global {
+  var JSCompiler_renameProperty: <P extends PropertyKey>(
+      prop: P, _obj: unknown) => P;
+
+  interface Window {
+    JSCompiler_renameProperty: typeof JSCompiler_renameProperty;
+  }
+}
 
 /**
  * Converts property values to and from attribute values.

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -14,7 +14,7 @@
 import {TemplateResult} from 'lit-html';
 import {render} from 'lit-html/lib/shady-render';
 
-import {PropertyValues, UpdatingElement, JSCompiler_renameProperty} from './lib/updating-element.js';
+import {PropertyValues, UpdatingElement} from './lib/updating-element.js';
 
 export * from './lib/updating-element.js';
 export * from './lib/decorators.js';


### PR DESCRIPTION
JSCompiler_renameProperty can't be exported from a module, it's a global. If it's exported then jscompiler doesn't treat it as special, it's just a normal function.
