### PR TITLE
Fix inherit  from constructor chain

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -73,8 +73,8 @@ export class LitElement extends UpdatingElement {
   private static get _uniqueStyles(): CSSResult[] {
     if (!this.hasOwnProperty(JSCompiler_renameProperty('_styles', this))) {
       // Inherit styles from superclass if none have been set.
-      if (!this.hasOwnProperty(JSCompiler_renameProperty('styles', this))) {
-        this._styles = this._styles !== undefined ? this._styles : [];
+      if (!this[JSCompiler_renameProperty('styles', this)]) {
+        this._styles = [];
       } else {
         // Take care not to call `this.styles` multiple times since this generates
         // new CSSResults each time.

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -690,6 +690,30 @@ suite('Static get styles', () => {
     assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(),
                  '4px');
   });
+
+  test('inherits `styles` from constructor chain', async () => {
+    const base = generateElementName();
+    customElements.define(base, class extends LitElement {
+      static get styles() { return css`div {
+          border: 2px solid blue;
+        }`;
+      }
+
+      render() {
+        return htmlWithStyles`
+        <div>Testing1</div>`;
+      }
+    });
+
+    const sub = generateElementName();
+    customElements.define(sub, class extends customElements.get(base) {});
+
+    const el = document.createElement(sub);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    const div = el.shadowRoot!.querySelector('div');
+    assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(), '2px');
+  });
 });
 
 suite('ShadyDOM', () => {


### PR DESCRIPTION
### Reference Issue
Fixes #467

Instead of checking 'current' constructor level only, this checks the whole constructor chain for `static get styles`. In this way, it never misses `styles` defined on constructors never 'ran' before (like mixins): https://stackblitz.com/edit/lit-element-request-update-bug-lspgdq?file=test.js

This could however mean that this._styles is created redundantly for constructor layers that should have the same outcome as their parents(and therefore should be able tor reuse `this._styles`). A code example that addresses this problem can be found here:
https://github.com/tlouisse/lit-element/blob/fix/getStylesFromConstructorChainAlternative/src/lit-element.ts#L92
But I'm not sure if this is more performant and outweighs the benefits of less code. 

Let me know what you think :)
