### PR TITLE
Do not return updateComplete at the end of requestUpdate

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -593,7 +593,6 @@ export abstract class UpdatingElement extends HTMLElement {
     if (!this._hasRequestedUpdate && shouldRequestUpdate) {
       this._enqueueUpdate();
     }
-    return this.updateComplete;
   }
 
   /**


### PR DESCRIPTION
This addresses an issue mentioned in #469. When implementing custom accessors, TS-Lint always has a finding on calling `requestUpdate`, because the result of the returned promise is ignored. As async and await is not supported in accessors anyway, my suggestion is to just not return `updateComplete`, as the return value is never used in the source code anyway and can easily be substituted for `updateComplete` get  accessor if needed.  
