### PR TITLE
Adds `unsafeCss` for composing values into `css`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 ## Unreleased
 
+### Added
+* Adds `unsafeCss` for composing "unsafe" values into `css`. Note, `CSSResult` is no longer constructable. ([#451](https://github.com/Polymer/lit-element/issues/451) and [#471](https://github.com/Polymer/lit-element/issues/471)).
+
 ### Fixed
 * Fixed a bug where we broke compatibility with closure compiler's property renaming optimizations. JSCompiler_renameProperty can't be a module export ([#465](https://github.com/Polymer/lit-element/pull/465)).
 * Fixed an issue with inheriting from `styles` property when extending a superclass that is never instanced. ([#470](https://github.com/Polymer/lit-element/pull/470)).

--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -44,7 +44,14 @@ export class CSSResult {
   }
 }
 
-export const unsafeCss = (value: any) => {
+/**
+ * Wrap a value for interpolation in a css tagged template literal.
+ *
+ * This is unsafe because untrusted CSS text can be used to phone home
+ * or exfiltrate data to an attacker controlled site. Take care to only use
+ * this with trusted input.
+ */
+export const unsafeCss = (value: unknown) => {
   return new CSSResult(String(value), constructionToken);
 };
 
@@ -54,10 +61,17 @@ const textFromCSSResult = (value: CSSResult) => {
   } else {
     throw new Error(
         `Value passed to 'css' function must be a 'css' function result: ${
-            value}.`);
+            value}. Use 'unsafeCss' to pass non-literal values, but
+            take care to ensure page security.` );
   }
 };
 
+/**
+ * Template tag which which can be used with LitElement's `style` property to
+ * set element styles. For security reasons, only literal string values may be
+ * used. To incorporate non-literal values `unsafeCss` may be used inside a
+ * template string part.
+ */
 export const css =
     (strings: TemplateStringsArray, ...values: CSSResult[]) => {
       const cssText = values.reduce(

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -16,6 +16,8 @@ import '@webcomponents/shadycss/apply-shim.min.js';
 
 import {
   css,
+  unsafeCss,
+  CSSResult,
   html as htmlWithStyles,
   LitElement,
 } from '../lit-element.js';
@@ -430,6 +432,33 @@ suite('Static get styles', () => {
 
   test('`css` get styles throws when unsafe values are used', async () => {
     assert.throws(() => { css`div { border: ${`2px solid blue;` as any}}`; });
+  });
+
+  test('`CSSResult` cannot be constructed', async () => {
+    // Note, this is done for security, instead use `css` or `unsafeCss`
+    assert.throws(() => { new CSSResult('throw', Symbol()); });
+  });
+
+  test('Any value can be used in `css` when included with `unsafeCss`', async () => {
+    const name = generateElementName();
+    const someVar = `2px solid blue`;
+    customElements.define(name, class extends LitElement {
+      static get styles() {
+        return css`div {
+          border: ${unsafeCss(someVar)};
+        }`;
+      }
+
+      render() {
+        return htmlWithStyles`
+        <div>Testing</div>`;
+      }
+    });
+    const el = document.createElement(name);
+    container.appendChild(el);
+    await (el as LitElement).updateComplete;
+    const div = el.shadowRoot!.querySelector('div');
+    assert.equal(getComputedStyleValue(div!, 'border-top-width').trim(), '2px');
   });
 
   test('styles in render compose with `static get styles`', async () => {


### PR DESCRIPTION
Fixes #451 and #471. Non-literal values can now be included in styling with `css` by using the `unsafeCss` function. This is named "unsafe" so users know this they must use this carefully to avoid security issues.