### PR TITLE
Removed comment about HTMLElementTagNameMap for customElement decorator

### DIFF
--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -67,20 +67,6 @@ const standardCustomElement =
  * Class decorator factory that defines the decorated class as a custom element.
  *
  * @param tagName the name of the custom element to define
- *
- * In TypeScript, the `tagName` passed to `customElement` should be a key of the
- * `HTMLElementTagNameMap` interface. To add your element to the interface,
- * declare the interface in this module:
- *
- *     @customElement('my-element')
- *     export class MyElement extends LitElement {}
- *
- *     declare global {
- *       interface HTMLElementTagNameMap {
- *         'my-element': MyElement;
- *       }
- *     }
- *
  */
 export const customElement = (tagName: string) => (
     classOrDescriptor: Constructor<HTMLElement>|ClassDescriptor) =>


### PR DESCRIPTION
Removed comment about HTMLElementTagNameMap for customElement decorator as this was changed to be a string in #291 . Thanks for spotting @katejeffreys.

<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
#291 