### PR TITLE
WIP and a proposal for updating the styles doc.

### DIFF
--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -6,7 +6,7 @@ slug: styles
 
 ## Shadow DOM
 
-LitElement uses [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) by default for DOM and style encapsulation. Shadow DOM scopes CSS so that styles defind in a shadow root only apply to DOM inside the shadow root and do not leak to outside DOM. Shadow roots are also isolated from styles defined outside the shadow root, whether in the main page or a outer shadow root.
+LitElement uses [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) by default for DOM and style encapsulation. Shadow DOM scopes CSS so that styles defined in a shadow root only apply to DOM inside the shadow root and do not leak to outside DOM. Shadow roots are also isolated from styles defined outside the shadow root, whether in the main page or an outer shadow root.
 
 **This guide applies only if you use the default (shadow DOM) render root.** If you modify your element's render root to render into the main DOM tree instead of a shadow root, these instructions won't apply.
 {.alert-info}

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -18,10 +18,10 @@ LitElement uses [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Co
 * ToC
 {:toc}
 
-## Styling shadow DOM
+### Styling shadow DOM
 
 Styles can be added to a shadow root in three different ways:
-* With styles defined in the static `styles` property of a LitElement class (reccomended).
+* With styles defined in the static `styles` property of a LitElement class (recommended).
 * With a `<style>` element in the shadow root
 * With a `<link rel="stylesheet">` element in the shadow root
 
@@ -66,13 +66,13 @@ class MySubElement extends MyElement {
 
 Here the subclass is explicitly inheriting the superclass styles, then adding its own.
 
-Static styles are the reccomended way to style LitElements because on browsers that support it, they generate and use a new standard called _[Constuctible Stylesheets](https://wicg.github.io/construct-stylesheets/)_, with a fallback for browsers that don't.
+Static styles are the recommended way to style LitElements because on browsers that support it, they generate and use a new standard called _[Constuctible Stylesheets](https://wicg.github.io/construct-stylesheets/)_, with a fallback for browsers that don't.
 
-Constuctible Stylesheets allow LitElement to parse styles exactly once and reuse the resulting Stylesheet object for maximum efficiency.
+Constructible Stylesheets allow LitElement to parse styles exactly once and reuse the resulting Stylesheet object for maximum efficiency.
 
 ### Limitations
 
-Static styles apply to all instances of an element. Any expressions in the style text are evaluated and included once, then reused for all instances. If you need to vary styles per-instance we reccomend using CSS custom properties, or inline styles.
+Static styles apply to all instances of an element. Any expressions in the style text are evaluated and included once, then reused for all instances. If you need to vary styles per-instance we recommend using CSS custom properties, or inline styles.
 
 For security reasons, the only types of values that can be interpolated into static styles are values returned by the `cssLiteral` and `unsafeCSS` template tags.
 
@@ -91,7 +91,7 @@ class MyElement extends LitElement {
 
 ## Inline styles
 
-You can also style a shadow root with inline styles right in your element template. We still reccomend static styles, but in some cases you may want to vary the CSS per-element. One way to do this is with bindings in `<style>` elements. It's important to note that this will not work with shadow DOM polyfills like ShadyCSS.
+You can also style a shadow root with inline styles right in your element template. We still recommend static styles, but in some cases you may want to vary the CSS per-element. One way to do this is with bindings in `<style>` elements. It's important to note that this will not work with shadow DOM polyfills like ShadyCSS.
 
 ```js
 import {LitElement, property} from 'lit-element';
@@ -110,7 +110,7 @@ class MyElement extends LitElement {
 }
 ```
 
-We strongly reccomend static styles, CSS custom properties, or [lit-html's `classMap` or `styleMap` directives](TODO) if you're stying non-host shadow root contents.
+We strongly recommend static styles, CSS custom properties, or [lit-html's `classMap` or `styleMap` directives](TODO) if you're stying non-host shadow root contents.
 
 ## External stylesheets
 
@@ -238,7 +238,7 @@ h1 {
 }
 ```
 
-## Inherited properties
+### Inherited properties
 
 [Inherited CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance), like `color`, `font-family`, and all CSS custom properties (`--*`) _do_ inherit through shadow root boundaries.
 

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -4,66 +4,247 @@ title: Styles
 slug: styles
 ---
 
+## Shadow DOM
+
+LitElement uses [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) by default for DOM and style encapsulation. Shadow DOM scopes CSS so that styles defind in a shadow root only apply to DOM inside the shadow root and do not leak to outside DOM. Shadow roots are also isolated from styles defined outside the shadow root, whether in the main page or a outer shadow root.
+
 **This guide applies only if you use the default (shadow DOM) render root.** If you modify your element's render root to render into the main DOM tree instead of a shadow root, these instructions won't apply.
+{.alert-info}
 
 **If you're using the Shady CSS polyfill, be aware that it has some limitations.** See the [Shady CSS README](https://github.com/webcomponents/shadycss/blob/master/README.md#limitations) for more information.
+{.alert-info}
 
 {::options toc_levels="1..3" /}
 * ToC
 {:toc}
 
-## Use the :host and :host() CSS pseudo-classes
+## Styling shadow DOM
 
-When styling your custom element, you can use the `:host` and `:host()` CSS pseudo-classes in a `<style>` block to select the host element (the element hosting the root of your shadow DOM). The two pseudo-classes slightly differ in usage:
+Styles can be added to a shadow root in three different ways:
+* With styles defined in the static `styles` property of a LitElement class (reccomended).
+* With a `<style>` element in the shadow root
+* With a `<link rel="stylesheet">` element in the shadow root
 
-* Use `:host(...)` when you need to apply a CSS selector (e.g. a class or attribute selector).
-* Use `:host` to refer to the host element, wihout further selection.
+These styles in turn can apply to different groups of elements:
+* The host element itself
+* Elements in the shadow root
+* Slotted elements: usually light DOM children that are projected into a `<slot>` element.
 
-Please note, that `:host` and `:host()` (with empty parentheses) do not behave the same. Here's a simple example:
+## Static styles
 
-_my-element.js_
+LitElements lets you define styles that apply to all instances with a static `styles` property on your element class.
 
+The value of the `styles` property must be created with the `css` template literal tag provided by the `lit-element` module. `styles` can either be a single value, or an array.
+
+An example of a single style:
 ```js
-render() {
-  return html`
-    <style>
-      :host([hidden]) { display: none; }
-      :host {
-        display: block; 
-        border: 1px solid black;
-      }
-    </style>
-    <p>Hello world</p>
+import {LitElement, css} from 'lit-element';
+
+class MyElement extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
   `;
 }
 ```
 
+Multiple values are useful for inheritance:
+
+```js
+class MySubElement extends MyElement {
+  static styles = [
+    super.styles,
+    css`
+      :host([.important]) {
+        color: red;
+      }
+    `
+  ];
+}
+```
+
+Here the subclass is explicitly inheriting the superclass styles, then adding its own.
+
+Static styles are the reccomended way to style LitElements because on browsers that support it, they generate and use a new standard called _[Constuctible Stylesheets](https://wicg.github.io/construct-stylesheets/)_, with a fallback for browsers that don't.
+
+Constuctible Stylesheets allow LitElement to parse styles exactly once and reuse the resulting Stylesheet object for maximum efficiency.
+
+### Limitations
+
+Static styles apply to all instances of an element. Any expressions in the style text are evaluated and included once, then reused for all instances. If you need to vary styles per-instance we reccomend using CSS custom properties, or inline styles.
+
+For security reasons, the only types of values that can be interpolated into static styles are values returned by the `cssLiteral` and `unsafeCSS` template tags.
+
+```js
+const mainColor = cssLiteral`red`;
+
+class MyElement extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      color: ${mainColor}
+    }
+  `;
+}
+```
+
+## Inline styles
+
+You can also style a shadow root with inline styles right in your element template. We still reccomend static styles, but in some cases you may want to vary the CSS per-element. One way to do this is with bindings in `<style>` elements. It's important to note that this will not work with shadow DOM polyfills like ShadyCSS.
+
+```js
+import {LitElement, property} from 'lit-element';
+
+class MyElement extends LitElement {
+  @property() mainColor = 'blue';
+  render() {
+    return html`
+      <style>
+        :host {
+          color: ${this.mainColor};
+        }
+      </style>
+    `;
+  }
+}
+```
+
+We strongly reccomend static styles, CSS custom properties, or [lit-html's `classMap` or `styleMap` directives](TODO) if you're stying non-host shadow root contents.
+
+## External stylesheets
+
+You can load an external stylesheet into a shadow root with a `<link>` element:
+
+```js
+import {LitElement} from 'lit-element';
+
+class MyElement extends LitElement {
+  render() {
+    return html`
+      <link rel="stylesheet" href="./styles.css">
+    `;
+  }
+}
+```
+
+This can be a good way to load CSS generated from tools like SASS/LESS.
+
+There are some important caveats though:
+
+* External styles can cause a flash-of-unstyled-content (FOUC) while they load.
+* The URL in the `href` attribute is relative to the _main document_, making this technique mostly useful for application elements where asset URLs are well known, and not for reusable elements published publically.
+
+
+## Styling the host element
+
+An element can apply styles to itself with the `:host` and `:host()` CSS psuedo-classes used inside the element's ShadowRoot. The tern "host" is used because an element is the host of its own shadow root.
+
+* `:host` selects the host element of the shadow root
+
+  ```css
+  :host {
+    display: block;
+    color: blue;
+  }
+  ```
+
+* `:host(...)` selects the host element, but only if the selector inside the parentheses matches the host element.
+
+  ```css
+  :host([.important]) {
+    color: red;
+    font-weight: bold;
+  }
+  ```
+
 {% include project.html folder="docs/style/hostselector" openFile="my-element.js" %}
 
-See the MDN documentation on [:host](https://developer.mozilla.org/en-US/docs/Web/CSS/:host), [:host()](https://developer.mozilla.org/en-US/docs/Web/CSS/:host()), and [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) for more information.
+**The :host CSS pseudo-class has higher specificity than the element's type selector.** Styles set for your host with the `:host` pseudo-class from inside its own shadow root will override styles set from outside its shadow root. For example:
 
-### Set host element display styles
-
-Two best practices for working with custom elements are:
-
-* Set a `:host` display style such as `block` or `inline-block` so that your component's `width` and `height` can be set.
-
-* Set a `:host()` display style that respects the `hidden` attribute.
+_index.html_ 
 
 ```html
 <style>
-  :host([hidden]) { display: none; }
-  :host { display: block; }
+  my-element { 
+    color: blue;
+  }
+</style>
+<my-element></my-element>
+```
+
+_my-element.js_
+
+```html
+<style>
+  /* Overrides styles set for my-element in index.html */
+  :host {
+    color: red;
+  }
 </style>
 ```
+
+See the MDN documentation on [:host](https://developer.mozilla.org/en-US/docs/Web/CSS/:host) and [:host()](https://developer.mozilla.org/en-US/docs/Web/CSS/:host()) for more information.
+
+
+### Host styling best practices
+
+Two best practices for working with custom elements are:
+
+* Add a `:host` display style (such as `block` or `inline-block`) unless you prefer the default of `inline`.
+
+  Inline elements are sized by their content and cannot have their dimensions set via CSS. They can also cause block element children to overflow its bounds.
+
+  ```css
+    :host {
+      display: block;
+    }
+  ```
+
+* Add a `:host()` display style that respects the `hidden` attribute.
+
+  ```css
+    :host([hidden]) {
+      display: none;
+    }
+  ```
 
 {% include project.html folder="docs/style/bestpracs" openFile="my-element.js" %}
 
 See [Custom Element Best Practices](https://developers.google.com/web/fundamentals/web-components/best-practices) for more information.
 
-### Style shadow DOM children via properties inherited via :host 
+## Styling elements in a shadow root
 
-Child elements in your template will inherit CSS properties you assign to your host via the `:host` CSS pseudo-class:
+Styling elements a shadow root is very straight forward: just use selectors that match your known content.
+
+Since CSS selectors in a shadow root only apply to elements in the shadow root, you don't need to be defensive against accidentally styling other elements in the page. This means you can generally write much simpler selectors, that are easier to reason about, and faster, than without shadow DOM.
+
+Simple selectors, like `*`, tagname, id and class selectors, are fine in a shadow root because they don't match outside the root:
+```css
+* {
+  color: black;
+}
+
+h1 {
+  font-size: 4rem;
+}
+
+#main {
+  padding: 16px;
+}
+
+.important {
+  color: red;
+}
+```
+
+## Inherited properties
+
+[Inherited CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance), like `color`, `font-family`, and all CSS custom properties (`--*`) _do_ inherit through shadow root boundaries.
+
+This means by default your elements will share some important styles from their outside context.
+
+You can take advantage of this to style all of a shadow root's contents by setting inherited properties on the host with the `:host` CSS pseudo-class:
 
 _my-element.js_
 
@@ -91,15 +272,33 @@ If your host element itself inherits properties from another element, the host's
   <style>
     div { font-family: Roboto; }
   </style>
-  ...
-  <div><my-element>Will use Roboto font</my-element></div>
+  <div>
+    <my-element>Will use Roboto font</my-element>
+  </div>
 ```
 
 {% include project.html folder="docs/style/inherited2" openFile="my-element.js" %}
 
-## Style the host from the main document
+## Styling slotted elements
 
-You can also style the host from outside its own template.
+Use the `::slotted()` CSS pseudo-element to select light DOM elements that have been included in shadow DOM via the `<slot>` element.
+
+* `::slotted(*)` matches all slotted elements.
+
+* `::slotted(p)` matches slotted paragraphs.
+
+* `p ::slotted(*)` matches slotted elements in a paragraph element.
+
+```js
+{% include projects/docs/style/slotted/my-element.js %}
+```
+
+{% include project.html folder="docs/style/slotted" openFile="my-element.js" %}
+
+
+## Styling custom elements from outside their shadow root
+
+You can style custom elements from outside its own shadow root.
 
 ### Use the custom element tag as a selector
 
@@ -119,34 +318,9 @@ _index.html_
 <my-element></my-element>
 ```
 
-**The :host CSS pseudo-class has higher specificity than the element's type selector.** Styles set for your host with the `:host` pseudo-class from inside its own template will override styles set in the main document. For example:
-
-_index.html_ 
-
-```html
-<style>
-  my-element { 
-    color: blue;
-  }
-</style>
-...
-<my-element></my-element>
-```
-
-_my-element.js_
-
-```html
-<style>
-  /* Overrides styles set for my-element in index.html */
-  :host {
-    color: red;
-  }
-</style>
-```
-
 ### Use custom properties
 
-Custom properties inherit down the DOM tree. You can use this to let your users apply styles and themes to your elements.
+Custom properties inherit down the DOM tree, and through shadow root boundaries You can use this to let your users apply styles and themes to your elements.
 
 For example, the following element sets its background color to a CSS variable that uses the value of the custom property `--myBackground` if it is available, and uses `yellow` otherwise:
 
@@ -193,22 +367,6 @@ If the user has an existing app theme, they can easily apply their theme propert
 {% include project.html folder="docs/style/customproperties" openFile="my-element.js" %}
 
 See [CSS Custom Properties on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) for more information.
-
-## Select slotted elements with the ::slotted() CSS pseudo-element
-
-Use the `::slotted()` CSS pseudo-element to select light DOM elements that have been included in shadow DOM via the `<slot>` element.
-
-* `::slotted(*)` matches all slotted elements.
-
-* `::slotted(p)` matches slotted paragraphs.
-
-* `p ::slotted(*)` matches slotted elements in a paragraph element.
-
-```js
-{% include projects/docs/style/slotted/my-element.js %}
-```
-
-{% include project.html folder="docs/style/slotted" openFile="my-element.js" %}
 
 ## Use JavaScript expressions in LitElement style blocks
 


### PR DESCRIPTION
This took a bit, so I had to rush something in before the end of day and it's a bit rough...

I added a brief intro to shadow DOM scoping, sections on static styles, inline styles and external styles, and tried to clarify the organization around what elements styles apply to: host, shadow root, or slotted.

Not sure if the top-level headings are right.
We also need to call into lit-html's styling docs when those are up.

Fixes #418 