### PR TITLE
[docs] Fix option name of `noAccessor`

### DIFF
--- a/docs/_guide/properties.md
+++ b/docs/_guide/properties.md
@@ -411,12 +411,12 @@ When you create custom property accessors for a property, LitElement still gener
 
 ### Prevent LitElement from generating a property accessor {#accessors-noaccessor}
 
-To prevent LitElement from generating property accessors, set `noAccessors` to `true` in the property declaration:
+To prevent LitElement from generating property accessors, set `noAccessor` to `true` in the property declaration:
 
 ```js
 static get properties() { return { 
   // Don't generate accessors for myProp
-  myProp: { type: Number, noAccessors: true } 
+  myProp: { type: Number, noAccessor: true } 
 
   // Do generate accessors for aProp
   aProp: { type: String }

--- a/docs/_includes/projects/properties/customsetter/my-element.js
+++ b/docs/_includes/projects/properties/customsetter/my-element.js
@@ -2,9 +2,9 @@ import { LitElement, html } from 'lit-element';
 
 class MyElement extends LitElement {
   static get properties() { return {
-    prop1: { type: Number, noAccessors: true },
+    prop1: { type: Number, noAccessor: true },
     prop2: { type: Number },
-    prop3: { type: Number, noAccessors: true },
+    prop3: { type: Number, noAccessor: true },
   };}
 
   set prop1(newVal) { this._prop1 = Math.floor(newVal); }


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->
no Issues

I found typos in docs :eyes: 