### PR TITLE
[docs] Add information about lit-html features in template syntax

### DIFF
--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -503,4 +503,7 @@ of the entire lit-html featureset for writing your templates:
 For example you can use the `nothing` sentinel value in case you want nothing to be rendered or you can use directives.
 You can find more information on writing templates with lit-html in the lit-html documentation:
 [Template Reference](https://github.com/Polymer/lit-html/blob/master/docs/_guide/05-template-reference.md)
-<!-- add link to published to https://github.com/Polymer/lit-html/blob/master/docs/_guide/05-template-reference.md once it is ready --!>
+
+
+To use features of lit-html thar are not part of the template syntax itself, but require an import such as `nothing` or directives you need to have lit-html installed as a dependency along side LitElement in your package.json. You can then use these features as specified in
+the [lit-html documentation](https://lit-html.polymer-project.org).

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -497,12 +497,11 @@ render() { return html`<slot name="thing"></slot>`; }
 </my-element>
 ```
 
-## Advanced features
-Since LitElement uses lit-html's `html` and `render` functions to render your template you can take advantage 
-of the entire lit-html featureset for writing your templates:
-For example you can use the `nothing` sentinel value in case you want nothing to be rendered or you can use directives.
-You can find more information on writing templates with lit-html in the lit-html documentation:
-[Template Reference](https://lit-html.polymer-project.org/guide/template-reference)
+## Further reading
+Since LitElement uses lit-html's `html` and `render` functions to render templates you can take advantage
+of the entire lit-html feature-set for writing your templates. You can find further information
+* [on the lit-html homepage](https://lit-html.polymer-project.org)
+* [in the Template Reference](https://lit-html.polymer-project.org/guide/template-reference)
 
 Note: Since lit-html is a dependency of LitElement it is installed into node_modules folder when you install LitElement. You do not have to install
 lit-html yourself. It is recommended that you only use the version of lit-html that comes as a dependency of your version of LitElement to avoid

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -496,3 +496,10 @@ render() { return html`<slot name="thing"></slot>`; }
   <p slot="thing">stuff</p>
 </my-element>
 ```
+
+## Advanced features
+Since LitElement uses lit-html's `html` and `render` functions to render your template you can take advantage 
+of the entire lit-html featureset for writing your templates:
+For example you can use the `nothing` sentinel value in case you want nothing to be rendered or you can use directives.
+You can find more information on writing templates with lit-html here:
+<!-- add link to https://github.com/Polymer/lit-html/blob/master/docs/_guide/05-template-reference.md once it is published --!>

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -502,7 +502,7 @@ Since LitElement uses lit-html's `html` and `render` functions to render your te
 of the entire lit-html featureset for writing your templates:
 For example you can use the `nothing` sentinel value in case you want nothing to be rendered or you can use directives.
 You can find more information on writing templates with lit-html in the lit-html documentation:
-[Template Reference](https://github.com/Polymer/lit-html/blob/master/docs/_guide/05-template-reference.md)
+[Template Reference](https://lit-html.polymer-project.org/guide/template-reference)
 
 
 To use features of lit-html thar are not part of the template syntax itself, but require an import such as `nothing` or directives you need to have lit-html installed as a dependency along side LitElement in your package.json. You can then use these features as specified in

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -504,6 +504,6 @@ For example you can use the `nothing` sentinel value in case you want nothing to
 You can find more information on writing templates with lit-html in the lit-html documentation:
 [Template Reference](https://lit-html.polymer-project.org/guide/template-reference)
 
-
-To use features of lit-html thar are not part of the template syntax itself, but require an import such as `nothing` or directives you need to have lit-html installed as a dependency along side LitElement in your package.json. You can then use these features as specified in
-the [lit-html documentation](https://lit-html.polymer-project.org).
+Note: Since lit-html is a dependency of LitElement it is installed into node_modules folder when you install LitElement. You do not have to install
+lit-html yourself. It is recommended that you only use the version of lit-html that comes as a dependency of your version of LitElement to avoid
+version conflicts.

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -501,5 +501,6 @@ render() { return html`<slot name="thing"></slot>`; }
 Since LitElement uses lit-html's `html` and `render` functions to render your template you can take advantage 
 of the entire lit-html featureset for writing your templates:
 For example you can use the `nothing` sentinel value in case you want nothing to be rendered or you can use directives.
-You can find more information on writing templates with lit-html here:
-<!-- add link to https://github.com/Polymer/lit-html/blob/master/docs/_guide/05-template-reference.md once it is published --!>
+You can find more information on writing templates with lit-html in the lit-html documentation:
+[Template Reference](https://github.com/Polymer/lit-html/blob/master/docs/_guide/05-template-reference.md)
+<!-- add link to published to https://github.com/Polymer/lit-html/blob/master/docs/_guide/05-template-reference.md once it is ready --!>


### PR DESCRIPTION
This is a draft of a fix for #506. It does add an advanced features section which says how to use lit-html and LitElement together. The link is just to the source code as apparently those docs are not live yet. 

@katejeffreys Is it intentional that lit-html is not really mentioned on this page? It feels like this page duplicates some parts of the lit-html documentation while never mentioning lit-html once. I would probably mention once that `html`is a lit-html function and that the syntax is the same and under the hood LitElement uses lit-html to render the template. 

Also `nothing` does not seem to be mentioned in the lit-html documentation, will open an issue for it.   