### PR TITLE
Fix cssResult.toString type

### DIFF
--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -44,7 +44,7 @@ export class CSSResult {
     return this._styleSheet;
   }
 
-  toString(): String {
+  toString(): string {
     return this.cssText;
   }
 }


### PR DESCRIPTION
Typescript uses the lowercase `string` type, not the `String` class.

Per https://github.com/Polymer/lit-element/pull/508#discussion_r254383556