### PR TITLE
[docs] Fix my-element.js for the completed code

### DIFF
--- a/docs/_try/create.md
+++ b/docs/_try/create.md
@@ -55,7 +55,7 @@ Here's the completed code for this step:
 _my-element.js_
 
 ```js
-{% include projects/try/create/before/my-element.js %}
+{% include projects/try/create/after/my-element.js %}
 ```
 
 Your code sample should be working now. LitElement components are added to a page with simple HTML tags, like this:


### PR DESCRIPTION
It should include `after/my-element.js`, not `before/my-element.js`

<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
