### PR TITLE
Add @ExportDecoratedItems annotations to query and queryAll decorators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Changed -->
 <!-- ### Removed -->
 <!-- ### Fixed -->
+
+## Unreleased
+### Changed
+* `LitElement.renderRoot` is now `public readonly` instead of `protected`.
+
+### Fixed
+* Properties annotated with the `@query` and `@queryAll` decorators will now
+  survive property renaming optimizations when used with tsickle and Closure JS
+  Compiler.
+
 ## [2.0.1] - 2019-02-05
 ### Fixed
 * Use `lit-html` 1.0 ([#543](https://github.com/Polymer/lit-element/pull/543)).

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -1,4 +1,3 @@
-
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -144,17 +143,48 @@ export function property(options?: PropertyDeclaration) {
 /**
  * A property decorator that converts a class property into a getter that
  * executes a querySelector on the element's renderRoot.
+ *
+ * @ExportDecoratedItems
  */
-export const query = _query(
-    (target: NodeSelector, selector: string) => target.querySelector(selector));
+export function query(selector: string) {
+  return (protoOrDescriptor: Object|ClassElement,
+          // tslint:disable-next-line:no-any decorator
+          name?: PropertyKey): any => {
+    const descriptor = {
+      get(this: LitElement) {
+        return this.renderRoot.querySelector(selector);
+      },
+      enumerable: true,
+      configurable: true,
+    };
+    return (name !== undefined) ?
+        legacyQuery(descriptor, protoOrDescriptor as Object, name) :
+        standardQuery(descriptor, protoOrDescriptor as ClassElement);
+  };
+}
 
 /**
  * A property decorator that converts a class property into a getter
  * that executes a querySelectorAll on the element's renderRoot.
+ *
+ * @ExportDecoratedItems
  */
-export const queryAll = _query(
-    (target: NodeSelector, selector: string) =>
-        target.querySelectorAll(selector));
+export function queryAll(selector: string) {
+  return (protoOrDescriptor: Object|ClassElement,
+          // tslint:disable-next-line:no-any decorator
+          name?: PropertyKey): any => {
+    const descriptor = {
+      get(this: LitElement) {
+        return this.renderRoot.querySelectorAll(selector);
+      },
+      enumerable: true,
+      configurable: true,
+    };
+    return (name !== undefined) ?
+        legacyQuery(descriptor, protoOrDescriptor as Object, name) :
+        standardQuery(descriptor, protoOrDescriptor as ClassElement);
+  };
+}
 
 const legacyQuery =
     (descriptor: PropertyDescriptor, proto: Object, name: PropertyKey) => {
@@ -168,32 +198,6 @@ const standardQuery = (descriptor: PropertyDescriptor, element: ClassElement) =>
       key: element.key,
       descriptor,
     });
-
-/**
- * Base-implementation of `@query` and `@queryAll` decorators.
- *
- * @param queryFn exectute a `selector` (ie, querySelector or querySelectorAll)
- * against `target`.
- * @suppress {visibility} The descriptor accesses an internal field on the
- * element.
- */
-function _query<T>(queryFn: (target: NodeSelector, selector: string) => T) {
-  return (selector: string) =>
-             (protoOrDescriptor: Object|ClassElement,
-              // tslint:disable-next-line:no-any decorator
-              name?: PropertyKey): any => {
-               const descriptor = {
-                 get(this: LitElement) {
-                   return queryFn(this.renderRoot!, selector);
-                 },
-                 enumerable: true,
-                 configurable: true,
-               };
-               return (name !== undefined) ?
-                   legacyQuery(descriptor, protoOrDescriptor as Object, name) :
-                   standardQuery(descriptor, protoOrDescriptor as ClassElement);
-             };
-}
 
 const standardEventOptions =
     (options: AddEventListenerOptions, element: ClassElement) => {

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -130,7 +130,7 @@ export class LitElement extends UpdatingElement {
    * Node or ShadowRoot into which element DOM should be rendered. Defaults
    * to an open shadowRoot.
    */
-  protected renderRoot?: Element|DocumentFragment;
+  readonly renderRoot!: Element|DocumentFragment;
 
   /**
    * Performs element initialization. By default this calls `createRenderRoot`
@@ -139,7 +139,8 @@ export class LitElement extends UpdatingElement {
    */
   protected initialize() {
     super.initialize();
-    this.renderRoot = this.createRenderRoot();
+    (this as {renderRoot: Element | DocumentFragment}).renderRoot =
+        this.createRenderRoot();
     // Note, if renderRoot is not a shadowRoot, styles would/could apply to the
     // element's getRootNode(). While this could be done, we're choosing not to
     // support this now since it would require different logic around de-duping.


### PR DESCRIPTION
This tells https://github.com/angular/tsickle to add Closure JS Compiler @export annotations to properties annotated with the `query` and `queryAll` decorators. We already did this for property and other decorators, but we also need it for these (due to the way that TypeScript generates decorator code which involves a static string of the property name).

Also makes `LitElement.renderRoot` `public readonly` instead of `protected` because the decorators need to access that property. Presumably this problem did not come up before because tsickle was not producing as correct types for Closure JS Compiler as it is now (maybe it doesn't understand the additional indirection we had before).
