### PR TITLE
remove in development status from api-readme

### DIFF
--- a/docs/_api/api-readme.md
+++ b/docs/_api/api-readme.md
@@ -1,6 +1,3 @@
-> ## 🛠 Status: In Development
-> LitElement is currently in development. It's on the fast track to a 1.0 release, so we encourage you to use it and give us your feedback, but there are things that haven't been finalized yet and you can expect some changes.
-
 # LitElement API Documentation
 
 ## Install lit-element


### PR DESCRIPTION
Since stable `lit-element` has already been released so `in development` status should be removed.
