### PR TITLE
Add file extensions fo imports where missing.

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -12,13 +12,13 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {TemplateResult} from 'lit-html';
-import {render} from 'lit-html/lib/shady-render';
+import {render} from 'lit-html/lib/shady-render.js';
 
 import {PropertyValues, UpdatingElement} from './lib/updating-element.js';
 
 export * from './lib/updating-element.js';
 export * from './lib/decorators.js';
-export {html, svg, TemplateResult, SVGTemplateResult} from 'lit-html/lit-html';
+export {html, svg, TemplateResult, SVGTemplateResult} from 'lit-html/lit-html.js';
 import {supportsAdoptingStyleSheets, CSSResult} from './lib/css-tag.js';
 export * from './lib/css-tag.js';
 


### PR DESCRIPTION
I was experimenting with [import maps](https://github.com/WICG/import-maps) in Chrome Canary. It won't be really useful for us until https://crbug.com/928149 (and, practically speaking) https://crbug.com/928149 are implemented, but it's at a really promising state!

This change ensures that when we're importing a file within another package, we give the full filename.