### PR TITLE
Ensure a property is reflect to attribute when it is changed after an attribute change

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -581,14 +581,16 @@ export abstract class UpdatingElement extends HTMLElement {
   requestUpdate(name?: PropertyKey, oldValue?: unknown) {
     let shouldRequestUpdate = true;
     // if we have a property key, perform property update steps.
-    if (name !== undefined && !this._changedProperties.has(name)) {
+    if (name !== undefined) {
       const ctor = this.constructor as typeof UpdatingElement;
       const options =
           ctor._classProperties!.get(name) || defaultPropertyDeclaration;
       if (ctor._valueHasChanged(
               this[name as keyof this], oldValue, options.hasChanged)) {
-        // track old value when changing.
-        this._changedProperties.set(name, oldValue);
+        if (!this._changedProperties.has(name)) {
+          // track old value when changing.
+          this._changedProperties.set(name, oldValue);
+        }
         // add to reflecting properties set
         if (options.reflect === true &&
             !(this._updateState & STATE_IS_REFLECTING_TO_PROPERTY)) {
@@ -596,6 +598,8 @@ export abstract class UpdatingElement extends HTMLElement {
             this._reflectingProperties = new Map();
           }
           this._reflectingProperties.set(name, options);
+        } else if (this._reflectingProperties && this._reflectingProperties.has(name)) {
+          this._reflectingProperties.delete(name);
         }
         // abort the request if the property should not be considered changed.
       } else {

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -729,7 +729,7 @@ suite('UpdatingElement', () => {
     assert.equal(el.getAttribute('custom'), '3');
     assert.equal(el.fromAttribute, 6);
     assert.equal(el.toAttribute, '7');
-    assert.equal(el.getAttribute('toattribute'), '7-attr');
+    assert.equal(el.getAttribute('toattribute'), '7');
     assert.equal(el.all, 11);
     assert.equal(el.getAttribute('all-attr'), '11-attr');
     assert.deepEqual(el.obj, {foo: true, bar: 5, baz: 'hi'});
@@ -2218,5 +2218,38 @@ suite('UpdatingElement', () => {
     container.appendChild(a);
     await a.updateComplete;
     assert.equal(a.updatedCalledCount, 1);
+  });
+
+  test('attribute change after a property change', async () => {
+    class E extends UpdatingElement {
+      static get properties() {
+        return {
+          disabled: {
+            type: Boolean,
+            reflect: true,
+            attribute: true
+          }
+        };
+      }
+      disabled = false;
+    }
+    const name = generateElementName();
+    customElements.define(name, E);
+    container.innerHTML = `<${name}></${name}>`;
+    const el = container.firstChild as E;
+    await el.updateComplete;
+    el.setAttribute('disabled', '');
+    el.removeAttribute('disabled');
+    el.disabled = true;
+    await el.updateComplete;
+    assert.isTrue(el.disabled);
+    assert.isTrue(el.hasAttribute('disabled'));
+    el.disabled = false;
+    await el.updateComplete;
+    el.setAttribute('disabled', '');
+    el.disabled = false;
+    await el.updateComplete;
+    assert.isFalse(el.disabled);
+    assert.isFalse(el.hasAttribute('disabled'));
   });
 });


### PR DESCRIPTION
Fixes #592

The update method is responsible to reflect property changes to attributes. Changing a property that has reflect equals true will populate the _reflectingProperties to indicate that the changed property must be reflected to its attribute.

There is a logic that prevents the property being changed from being added to the _reflectingProperties, if the property change was caused by an attribute change.

There is also the _changedProperties map that contains the keys for any properties that have changed since the last update cycle.

If the the same property is changed multiple times on the same update cycle, of course its key is added just once _changedProperties map.

The problem occurs when you change an attribute and on the sae update cycle change the property. In this scenario, when you change the attribute then the property is not added to the _reflectingProperties map. iI after changing the attribute, you change the property then the property is already on the _changedProperties map and the logic that adds the property to the _reflectingProperties is not executed in this case.

This leads to the update method to not reflect the property change to the attribute.

I changed the updating-element.ts code to add to the _reflectingProperties map when the property is changed, even if the property is already on the _changedProperties map. Also if the property change come from an attribute change I remove the property from the  _reflectingProperties map.