### PR TITLE
Remove unnecessary type assertions

### DIFF
--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -72,8 +72,8 @@ export const customElement = (tagName: string) =>
     (classOrDescriptor: Constructor<HTMLElement>|ClassDescriptor) =>
         (typeof classOrDescriptor === 'function') ?
     legacyCustomElement(
-        tagName, classOrDescriptor as Constructor<HTMLElement>) :
-    standardCustomElement(tagName, classOrDescriptor as ClassDescriptor);
+        tagName, classOrDescriptor) :
+    standardCustomElement(tagName, classOrDescriptor);
 
 const standardProperty =
     (options: PropertyDeclaration, element: ClassElement) => {
@@ -109,7 +109,7 @@ const standardProperty =
           // tslint:disable-next-line:no-any decorator
           initializer(this: any) {
             if (typeof element.initializer === 'function') {
-              this[element.key] = element.initializer!.call(this);
+              this[element.key] = element.initializer.call(this);
             }
           },
           finisher(clazz: typeof UpdatingElement) {
@@ -122,7 +122,7 @@ const standardProperty =
 const legacyProperty =
     (options: PropertyDeclaration, proto: Object, name: PropertyKey) => {
       (proto.constructor as typeof UpdatingElement)
-          .createProperty(name!, options);
+          .createProperty(name, options);
     };
 
 /**

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -71,8 +71,7 @@ const standardCustomElement =
 export const customElement = (tagName: string) =>
     (classOrDescriptor: Constructor<HTMLElement>|ClassDescriptor) =>
         (typeof classOrDescriptor === 'function') ?
-    legacyCustomElement(
-        tagName, classOrDescriptor) :
+    legacyCustomElement(tagName, classOrDescriptor) :
     standardCustomElement(tagName, classOrDescriptor);
 
 const standardProperty =

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -296,8 +296,7 @@ export abstract class UpdatingElement extends HTMLElement {
     Object.defineProperty(this.prototype, name, {
       // tslint:disable-next-line:no-any no symbol in index
       get(): any {
-        // tslint:disable-next-line:no-any no symbol in index
-        return (this as any)[key];
+        return this[key];
       },
       set(this: UpdatingElement, value: unknown) {
         // tslint:disable-next-line:no-any no symbol in index
@@ -632,6 +631,8 @@ export abstract class UpdatingElement extends HTMLElement {
         typeof (result as PromiseLike<unknown>).then === 'function') {
       await result;
     }
+    // TypeScript can't tell that we've initialized resolve.
+    // tslint:disable-next-line:no-unnecessary-type-assertion
     resolve!(!this._hasRequestedUpdate);
   }
 

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -117,7 +117,7 @@ export class LitElement extends UpdatingElement {
         return set;
       }, new Set<CSSResult>());
       // Array.from does not work on Set in IE
-      styleSet.forEach((v) => styles!.unshift(v));
+      styleSet.forEach((v) => styles.unshift(v));
     } else if (userStyles) {
       styles.push(userStyles);
     }
@@ -214,8 +214,8 @@ export class LitElement extends UpdatingElement {
       (this.constructor as typeof LitElement)
           .render(
               templateResult,
-              this.renderRoot!,
-              {scopeName: this.localName!, eventContext: this});
+              this.renderRoot,
+              {scopeName: this.localName, eventContext: this});
     }
     // When native Shadow DOM is used but adoptedStyles are not supported,
     // insert styling after rendering to ensure adoptedStyles have highest
@@ -225,7 +225,7 @@ export class LitElement extends UpdatingElement {
       (this.constructor as typeof LitElement)._styles!.forEach((s) => {
         const style = document.createElement('style');
         style.textContent = s.cssText;
-        this.renderRoot!.appendChild(style);
+        this.renderRoot.appendChild(style);
       });
     }
   }

--- a/src/test/lib/decorators_test.ts
+++ b/src/test/lib/decorators_test.ts
@@ -372,7 +372,7 @@ suite('decorators', () => {
       const c = new C();
       container.appendChild(c);
       await c.updateComplete;
-      const divs = c.divs!;
+      const divs = c.divs;
       // This is not true in ShadyDOM:
       // assert.instanceOf(divs, NodeList);
       assert.lengthOf(divs, 2);

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -201,7 +201,7 @@ suite('Styling', () => {
         div = inner!.shadowRoot!.querySelector('div');
         assert.equal(
             getComputedStyleValue(div!, 'border-top-width').trim(), '2px');
-        el2!.shadowRoot!.appendChild(inner!);
+        el2.shadowRoot!.appendChild(inner!);
 
         // Workaround for Safari 9 Promise timing bugs.
         await el.updateComplete;
@@ -307,14 +307,14 @@ suite('Styling', () => {
 
         // Workaround for Safari 9 Promise timing bugs.
         await firstApplied.updateComplete && el.updateComplete &&
-            await (el.applied as I)!.updateComplete;
+            await (el.applied as I).updateComplete;
 
         await nextFrame();
         assert.equal(
-            getComputedStyleValue(firstApplied!, 'border-top-width').trim(),
+            getComputedStyleValue(firstApplied, 'border-top-width').trim(),
             '2px');
         assert.equal(
-            getComputedStyleValue(firstApplied!, 'margin-top').trim(), '10px');
+            getComputedStyleValue(firstApplied, 'margin-top').trim(), '10px');
         assert.equal(
             getComputedStyleValue(el.applied!, 'border-top-width').trim(),
             '10px');

--- a/tslint.json
+++ b/tslint.json
@@ -13,6 +13,7 @@
     "no-internal-module": true,
     "no-trailing-whitespace": true,
     "no-var-keyword": true,
+    "no-unnecessary-type-assertion": true,
     "one-line": [
       true,
       "check-open-brace",


### PR DESCRIPTION
This is the result of turning on the no-unnecessary-type-assertion tslint pass and running `--fix`. There was one place where I disabled this pass where we needed `!` to note that a variable was definitely  assigned to before it was read.

I like this lint pass because it makes the code a bit easier to read and understand. I will admit though that I'm proposing this change because we use this lint pass downstream, and it's annoying seeing the lint warnings.
