### PR TITLE
Replaces cssLiteral (removed) with unsafeCSS 

### DIFF
--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -111,26 +111,32 @@ To define a static `styles` property:
 
 #### Expressions in static styles
 
+The `css` tag only accepts literal strings. You can include expressions in your static styles using the `unsafeCSS` tag instead. 
+
 Static styles apply to all instances of an element. Any expressions in your CSS are evaluated and included **once**, then reused for all instances. 
 
-For security reasons, use **unsafeCSS** to pass non-literal values using only trusted sources:
+Example:
 
 ```js
-import {LitElement, css, unsafeCSS} from 'lit-element';
-
-const displayType = css`block`;
-const mainColor = unsafeCSS('#a50e0e');
+import { LitElement, unsafeCSS } from 'lit-element';
 
 class MyElement extends LitElement {
   static get styles() {
-    return css`
-    :host {
-      display: ${displayType};
-      color: ${mainColor};
-    }`;
+    return unsafeCSS`
+      :host {
+        display: ${this.getDisplayType()};
+        color: ${this.getMainColor()};
+      }
+    `;
   } 
 }
 ```
+
+<div class="alert alert-warning">
+
+**Only use the `unsafeCSS` tag with trusted input.** To prevent LitElement-based components from evaluating potentially malicious code, the `css` tag only accepts literal strings. `unsafeCSS` circumvents this safeguard.
+
+</div>
 
 ### Define styles in a style element {#style-element} 
 

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -118,7 +118,7 @@ For security reasons, use unsafeCSS to pass non-literal values using only truste
 ```js
 import { unsafeCSS } from 'lit-element';
 
-const mainColor = unsafeCSS('red');
+const mainColor = css`red`;
 
 class MyElement extends LitElement {
   static get styles() {

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -113,10 +113,10 @@ To define a static `styles` property:
 
 Static styles apply to all instances of an element. Any expressions in your CSS are evaluated and included **once**, then reused for all instances. 
 
-For security reasons, use unsafeCSS to pass non-literal values using only trusted sources:
+For security reasons, use **css** to pass non-literal values using only trusted sources:
 
 ```js
-import { unsafeCSS } from 'lit-element';
+import {LitElement, css} from 'lit-element';
 
 const mainColor = css`red`;
 

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -113,19 +113,19 @@ To define a static `styles` property:
 
 Static styles apply to all instances of an element. Any expressions in your CSS are evaluated and included **once**, then reused for all instances. 
 
-For security reasons, expressions must be tagged with the `cssLiteral` template literal tag:
+For security reasons, you must use unsafeCSS to pass non-literal values:
 
 ```js
-import { LitElement, css, cssLiteral } from 'lit-element';
+import { unsafeCSS } from 'lit-element';
 
-const mainColor = cssLiteral`red`;
+const mainColor = unsafeCSS('red');
 
 class MyElement extends LitElement {
   static get styles() {
     return css`
     :host {
       display: block;
-      color: ${mainColor}
+      color: ${mainColor};
     }`;
   } 
 }

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -113,7 +113,7 @@ To define a static `styles` property:
 
 Static styles apply to all instances of an element. Any expressions in your CSS are evaluated and included **once**, then reused for all instances. 
 
-For security reasons, you must use unsafeCSS to pass non-literal values:
+For security reasons, use unsafeCSS to pass non-literal values using only trusted sources:
 
 ```js
 import { unsafeCSS } from 'lit-element';

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -113,18 +113,19 @@ To define a static `styles` property:
 
 Static styles apply to all instances of an element. Any expressions in your CSS are evaluated and included **once**, then reused for all instances. 
 
-For security reasons, use **css** to pass non-literal values using only trusted sources:
+For security reasons, use **unsafeCSS** to pass non-literal values using only trusted sources:
 
 ```js
-import {LitElement, css} from 'lit-element';
+import {LitElement, css, unsafeCSS} from 'lit-element';
 
-const mainColor = css`red`;
+const displayType = css`block`;
+const mainColor = unsafeCSS('#a50e0e');
 
 class MyElement extends LitElement {
   static get styles() {
     return css`
     :host {
-      display: block;
+      display: ${displayType};
       color: ${mainColor};
     }`;
   } 

--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -111,21 +111,53 @@ To define a static `styles` property:
 
 #### Expressions in static styles
 
-The `css` tag only accepts literal strings. You can include expressions in your static styles using the `unsafeCSS` tag instead. 
-
 Static styles apply to all instances of an element. Any expressions in your CSS are evaluated and included **once**, then reused for all instances. 
 
-Example:
+To prevent LitElement-based components from evaluating potentially malicious code, the `css` tag only accepts literal strings. You can nest them like this:
 
 ```js
-import { LitElement, unsafeCSS } from 'lit-element';
+static get styles() {
+  const mainColor = css`red`;
+
+  return css`
+    :host { 
+      color: ${mainColor}; 
+    }
+  `;
+}
+```
+
+However, if you want to inject any variable or non-literal into a css string, you must wrap it with the `unsafeCSS` function. For example:
+
+```js
+import { LitElement, css, unsafeCSS } from 'lit-element';
 
 class MyElement extends LitElement {
   static get styles() {
-    return unsafeCSS`
-      :host {
-        display: ${this.getDisplayType()};
-        color: ${this.getMainColor()};
+    const mainColor = 'red';
+    
+    return css`
+      :host { 
+        color: ${unsafeCSS(mainColor)};
+      }
+    `;
+  } 
+}
+```
+
+Another example:
+
+```js
+import { LitElement, css, unsafeCSS } from 'lit-element';
+
+class MyElement extends LitElement {
+  static get styles() {
+    const mainWidth = 800;
+    const padding = 20;   
+    
+    return css`
+      :host { 
+        width: ${unsafeCSS(mainWidth + padding)}px;
       }
     `;
   } 


### PR DESCRIPTION
Updates style guide by removing reference to cssLiteral (previously removed) for using expressions in static styles with unsafeCSS method.
