### PR TITLE
Update Lifecycle doc's broken link to Properties

### DIFF
--- a/docs/_guide/lifecycle.md
+++ b/docs/_guide/lifecycle.md
@@ -79,7 +79,7 @@ In call order, the methods and properties in the update lifecycle are:
 
 All declared properties have a function, `hasChanged`, which is called whenever the property is set; if `hasChanged` returns true, an update is scheduled.
 
-See the Properties documentation for information on [configuring `hasChanged` to customize what constitutes a property change](/properties#configure-property-changes).
+See the Properties documentation for information on [configuring `hasChanged` to customize what constitutes a property change](/guide/properties#haschanged).
 
 ### requestUpdate {#requestupdate}
 


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
This corrects the format of a intra-docs link, fixing #587 and #510 alongside #517. #517 provides the relevant anchor, this patch should cause this link to resolve to that section (instead of 404ing)

