### PR TITLE
Handle exceptions during update so that they do not break subsequent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * `LitElement.renderRoot` is now `public readonly` instead of `protected`.
 
 ### Fixed
+* Exceptions generated during update/render do not block subsequent updates ([#262](https://github.com/Polymer/lit-element/issues/262)).
 * Properties annotated with the `@query` and `@queryAll` decorators will now
   survive property renaming optimizations when used with tsickle and Closure JS
   Compiler.

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -644,10 +644,9 @@ export abstract class UpdatingElement extends HTMLElement {
     try {
       const result = this.performUpdate();
       // If `performUpdate` returns a Promise, we await it. This is done to
-      // enable coordinating updates with a scheduler. Note, the result type is
+      // enable coordinating updates with a scheduler. Note, the result is
       // checked to avoid delaying an additional microtask unless we need to.
-      if (result != null &&
-          typeof (result as PromiseLike<unknown>).then === 'function') {
+      if (result != null) {
         await result;
       }
     } catch (e) {

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -620,9 +620,9 @@ export abstract class UpdatingElement extends HTMLElement {
       resolve = res;
       reject = rej;
     });
-    // Ensure any previous update has resolved before updating.
-    // This `await` also ensures that property changes are batched.
     try {
+      // Ensure any previous update has resolved before updating.
+      // This `await` also ensures that property changes are batched.
       await previousUpdatePromise;
     } catch (e) {
       // Ignore any previous errors. We only care that the previous cycle is
@@ -647,7 +647,6 @@ export abstract class UpdatingElement extends HTMLElement {
       this._markUpdated();
       reject(e);
     }
-    // TypeScript can't tell that we've initialized resolve.
     resolve(!this._hasRequestedUpdate);
   }
 

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -303,7 +303,7 @@ export abstract class UpdatingElement extends HTMLElement {
         const oldValue = (this as any)[name];
         // tslint:disable-next-line:no-any no symbol in index
         (this as any)[key] = value;
-        this.requestUpdate(name, oldValue);
+        this._requestUpdate(name, oldValue);
       },
       configurable: true,
       enumerable: true
@@ -565,19 +565,11 @@ export abstract class UpdatingElement extends HTMLElement {
   }
 
   /**
-   * Requests an update which is processed asynchronously. This should
-   * be called when an element should update based on some state not triggered
-   * by setting a property. In this case, pass no arguments. It should also be
-   * called when manually implementing a property setter. In this case, pass the
-   * property `name` and `oldValue` to ensure that any configured property
-   * options are honored. Returns the `updateComplete` Promise which is resolved
-   * when the update completes.
-   *
-   * @param name {PropertyKey} (optional) name of requesting property
-   * @param oldValue {any} (optional) old value of requesting property
-   * @returns {Promise} A Promise that is resolved when the update completes.
+   * This private version of `requestUpdate` does not access or return the
+   * `updateComplete` promise. This promise can be overridden and is therefore
+   * not free to access.
    */
-  requestUpdate(name?: PropertyKey, oldValue?: unknown) {
+  private _requestUpdate(name?: PropertyKey, oldValue?: unknown) {
     let shouldRequestUpdate = true;
     // if we have a property key, perform property update steps.
     if (name !== undefined && !this._changedProperties.has(name)) {
@@ -604,6 +596,23 @@ export abstract class UpdatingElement extends HTMLElement {
     if (!this._hasRequestedUpdate && shouldRequestUpdate) {
       this._enqueueUpdate();
     }
+  }
+
+  /**
+   * Requests an update which is processed asynchronously. This should
+   * be called when an element should update based on some state not triggered
+   * by setting a property. In this case, pass no arguments. It should also be
+   * called when manually implementing a property setter. In this case, pass the
+   * property `name` and `oldValue` to ensure that any configured property
+   * options are honored. Returns the `updateComplete` Promise which is resolved
+   * when the update completes.
+   *
+   * @param name {PropertyKey} (optional) name of requesting property
+   * @param oldValue {any} (optional) old value of requesting property
+   * @returns {Promise} A Promise that is resolved when the update completes.
+   */
+  requestUpdate(name?: PropertyKey, oldValue?: unknown) {
+    this._requestUpdate(name, oldValue);
     return this.updateComplete;
   }
 
@@ -632,7 +641,6 @@ export abstract class UpdatingElement extends HTMLElement {
     if (!this._hasConnected) {
       await new Promise((res) => this._hasConnectedResolver = res);
     }
-    // Trap errors in updating so that element is not in a non-functional state.
     try {
       const result = this.performUpdate();
       // If `performUpdate` returns a Promise, we await it. This is done to
@@ -643,8 +651,6 @@ export abstract class UpdatingElement extends HTMLElement {
         await result;
       }
     } catch (e) {
-      // Ensure subsequent updates are ok but reject this update.
-      this._markUpdated();
       reject(e);
     }
     resolve(!this._hasRequestedUpdate);
@@ -663,10 +669,13 @@ export abstract class UpdatingElement extends HTMLElement {
   }
 
   /**
-   * Performs an element update.
+   * Performs an element update. Note, if an exception is thrown during the
+   * update, `firstUpdated` and `updated` will not be called.
    *
-   * You can override this method to change the timing of updates. For instance,
-   * to schedule updates to occur just before the next frame:
+   * You can override this method to change the timing of updates. If this
+   * method is overridden, `super.performUpdate()` must be called.
+   *
+   * For instance, to schedule updates to occur just before the next frame:
    *
    * ```
    * protected async performUpdate(): Promise<unknown> {
@@ -680,17 +689,28 @@ export abstract class UpdatingElement extends HTMLElement {
     if (this._instanceProperties) {
       this._applyInstanceProperties();
     }
-    if (this.shouldUpdate(this._changedProperties)) {
-      const changedProperties = this._changedProperties;
-      this.update(changedProperties);
+    let shouldUpdate = false;
+    const changedProperties = this._changedProperties;
+    try {
+      shouldUpdate = this.shouldUpdate(changedProperties);
+      if (shouldUpdate) {
+        this.update(changedProperties);
+      }
+    } catch (e) {
+      // Prevent `firstUpdated` and `updated` from running when there's an
+      // update exception.
+      shouldUpdate = false;
+      throw e;
+    } finally {
+      // Ensure element can accept additional updates after an exception.
       this._markUpdated();
+    }
+    if (shouldUpdate) {
       if (!(this._updateState & STATE_HAS_UPDATED)) {
         this._updateState = this._updateState | STATE_HAS_UPDATED;
         this.firstUpdated(changedProperties);
       }
       this.updated(changedProperties);
-    } else {
-      this._markUpdated();
     }
   }
 
@@ -703,7 +723,8 @@ export abstract class UpdatingElement extends HTMLElement {
    * Returns a Promise that resolves when the element has completed updating.
    * The Promise value is a boolean that is `true` if the element completed the
    * update without triggering another update. The Promise result is `false` if
-   * a property was set inside `updated()`. This getter can be implemented to
+   * a property was set inside `updated()`. If the Promise is rejected, an
+   * exception was thrown during the update. This getter can be implemented to
    * await additional state. For example, it is sometimes useful to await a
    * rendered element before fulfilling this Promise. To do this, first await
    * `super.updateComplete` then any subsequent state.

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -613,8 +613,8 @@ export abstract class UpdatingElement extends HTMLElement {
   private async _enqueueUpdate() {
     // Mark state updating...
     this._updateState = this._updateState | STATE_UPDATE_REQUESTED;
-    let resolve: (r: boolean) => void;
-    let reject: (e: Error) => void;
+    let resolve!: (r: boolean) => void;
+    let reject!: (e: Error) => void;
     const previousUpdatePromise = this._updatePromise;
     this._updatePromise = new Promise((res, rej) => {
       resolve = res;
@@ -640,7 +640,7 @@ export abstract class UpdatingElement extends HTMLElement {
     } catch (e) {
       // Ensure subsequent updates are ok but reject this update.
       this._markUpdated();
-      reject!(e);
+      reject(e);
     }
     // Note, this is to avoid delaying an additional microtask unless we need
     // to.
@@ -651,12 +651,11 @@ export abstract class UpdatingElement extends HTMLElement {
       } catch (e) {
         // Ensure subsequent updates are ok but reject this update.
         this._markUpdated();
-        reject!(e);
+        reject(e);
       }
     }
     // TypeScript can't tell that we've initialized resolve.
-    // tslint:disable-next-line:no-unnecessary-type-assertion
-    resolve!(!this._hasRequestedUpdate);
+    resolve(!this._hasRequestedUpdate);
   }
 
   private get _hasConnected() {

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -2219,4 +2219,172 @@ suite('UpdatingElement', () => {
     await a.updateComplete;
     assert.equal(a.updatedCalledCount, 1);
   });
+
+  test('exceptions in `update` throw but do not prevent further updates', async () => {
+    let shouldThrow = false;
+    class A extends UpdatingElement {
+
+      @property() foo = 5;
+      updatedFoo = 0;
+
+      update(changedProperties: Map<PropertyKey, unknown>) {
+        if (shouldThrow) {
+          throw new Error('test error');
+        }
+        super.update(changedProperties);
+      }
+
+      updated(_changedProperties: Map<PropertyKey, unknown>) {
+        this.updatedFoo = this.foo;
+      }
+    }
+    customElements.define(generateElementName(), A);
+    const a = new A();
+    document.body.appendChild(a);
+    await a.updateComplete;
+    assert.equal(a.updatedFoo, 5);
+    shouldThrow = true;
+    a.foo = 10;
+    let threw = false;
+    try {
+      await a.updateComplete;
+    } catch (e) {
+      threw = true;
+    }
+    assert.isTrue(threw);
+    assert.equal(a.foo, 10);
+    assert.equal(a.updatedFoo, 5);
+    shouldThrow = false;
+    a.foo = 20;
+    await a.updateComplete;
+    assert.equal(a.foo, 20);
+    assert.equal(a.updatedFoo, 20);
+    document.body.removeChild(a);
+  });
+
+  test('exceptions in `updated` throw but do not prevent further updates', async () => {
+    let shouldThrow = false;
+    class A extends UpdatingElement {
+
+      @property() foo = 5;
+      updatedFoo = 0;
+
+      updated(_changedProperties: Map<PropertyKey, unknown>) {
+        if (shouldThrow) {
+          throw new Error('test error');
+        }
+        this.updatedFoo = this.foo;
+      }
+    }
+    customElements.define(generateElementName(), A);
+    const a = new A();
+    document.body.appendChild(a);
+    await a.updateComplete;
+    assert.equal(a.updatedFoo, 5);
+    shouldThrow = true;
+    a.foo = 10;
+    let threw = false;
+    try {
+      await a.updateComplete;
+    } catch (e) {
+      threw = true;
+    }
+    assert.isTrue(threw);
+    assert.equal(a.foo, 10);
+    assert.equal(a.updatedFoo, 5);
+    shouldThrow = false;
+    a.foo = 20;
+    await a.updateComplete;
+    assert.equal(a.foo, 20);
+    assert.equal(a.updatedFoo, 20);
+    document.body.removeChild(a);
+  });
+
+  test('exceptions in `shouldUpdate` throw but do not prevent further updates', async () => {
+    let shouldThrow = false;
+    class A extends UpdatingElement {
+
+      @property() foo = 5;
+      updatedFoo = 0;
+
+      shouldUpdate(changedProperties: Map<PropertyKey, unknown>) {
+        if (shouldThrow) {
+          throw new Error('test error');
+        }
+        return super.shouldUpdate(changedProperties);
+      }
+
+      updated(_changedProperties: Map<PropertyKey, unknown>) {
+        this.updatedFoo = this.foo;
+      }
+    }
+    customElements.define(generateElementName(), A);
+    const a = new A();
+    document.body.appendChild(a);
+    await a.updateComplete;
+    assert.equal(a.updatedFoo, 5);
+    shouldThrow = true;
+    a.foo = 10;
+    let threw = false;
+    try {
+      await a.updateComplete;
+    } catch (e) {
+      threw = true;
+    }
+    assert.isTrue(threw);
+    assert.equal(a.foo, 10);
+    assert.equal(a.updatedFoo, 5);
+    shouldThrow = false;
+    a.foo = 20;
+    await a.updateComplete;
+    assert.equal(a.foo, 20);
+    assert.equal(a.updatedFoo, 20);
+    document.body.removeChild(a);
+  });
+
+  test('exceptions in `performUpdate` throw but do not prevent further updates', async () => {
+    let shouldThrow = false;
+    class A extends UpdatingElement {
+
+      @property() foo = 5;
+      updatedFoo = 0;
+
+      updated(_changedProperties: Map<PropertyKey, unknown>) {
+        this.updatedFoo = this.foo;
+      }
+
+      performUpdate() {
+        super.performUpdate();
+        return new Promise((resolve, reject) => {
+          if (shouldThrow) {
+            reject();
+          } else {
+            resolve();
+          }
+        });
+      }
+    }
+    customElements.define(generateElementName(), A);
+    const a = new A();
+    document.body.appendChild(a);
+    await a.updateComplete;
+    assert.equal(a.updatedFoo, 5);
+    shouldThrow = true;
+    a.foo = 10;
+    let threw = false;
+    try {
+      await a.updateComplete;
+    } catch (e) {
+      threw = true;
+    }
+    assert.isTrue(threw);
+    assert.equal(a.foo, 10);
+    assert.equal(a.updatedFoo, 10);
+    shouldThrow = false;
+    a.foo = 20;
+    await a.updateComplete;
+    assert.equal(a.foo, 20);
+    assert.equal(a.updatedFoo, 20);
+    document.body.removeChild(a);
+  });
 });

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -2386,12 +2386,12 @@ suite('UpdatingElement', () => {
       threw = true;
     }
     assert.isTrue(threw);
-    assert.isFalse(a.changedProps!.has('foo'));
+    assert.isFalse(a.changedProps.has('foo'));
     assert.equal(a.foo, 10);
     assert.equal(a.updatedFoo, 5);
     a.foo = 20;
     await a.updateComplete;
-    assert.equal(a.changedProps!.get('foo'), 10);
+    assert.equal(a.changedProps.get('foo'), 10);
     assert.equal(a.foo, 20);
     assert.equal(a.updatedFoo, 20);
     enqueue = true;
@@ -2404,7 +2404,7 @@ suite('UpdatingElement', () => {
       threw = true;
     }
     assert.isTrue(threw);
-    assert.equal(a.changedProps!.get('foo'), 50);
+    assert.equal(a.changedProps.get('foo'), 50);
     assert.equal(a.foo, 51);
     assert.equal(a.updatedFoo, 51);
   });

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1570,7 +1570,7 @@ suite('UpdatingElement', () => {
 
     const el = new E();
     el.foo = 'foo1';
-    document.body.appendChild(el);
+    container.appendChild(el);
     await el.updateComplete;
     assert.equal(el.foo, 'foo1');
     assert.equal(el.bar, 'defaultBar');
@@ -1804,7 +1804,7 @@ suite('UpdatingElement', () => {
 
     const el = new E();
     el.foo = 'foo1';
-    document.body.appendChild(el);
+    container.appendChild(el);
     await el.updateComplete;
     assert.equal(el.foo, 'foo1');
     assert.equal(el.bar, 'defaultBar');
@@ -1865,7 +1865,7 @@ suite('UpdatingElement', () => {
 
     const el = new E();
     el.foo = 'foo1';
-    document.body.appendChild(el);
+    container.appendChild(el);
     await el.updateComplete;
     assert.equal(el.foo, 'foo1');
     assert.equal(el.bar, 'defaultBar');
@@ -2240,7 +2240,7 @@ suite('UpdatingElement', () => {
     }
     customElements.define(generateElementName(), A);
     const a = new A();
-    document.body.appendChild(a);
+    container.appendChild(a);
     await a.updateComplete;
     assert.equal(a.updatedFoo, 5);
     shouldThrow = true;
@@ -2259,7 +2259,6 @@ suite('UpdatingElement', () => {
     await a.updateComplete;
     assert.equal(a.foo, 20);
     assert.equal(a.updatedFoo, 20);
-    document.body.removeChild(a);
   });
 
   test('exceptions in `updated` throw but do not prevent further updates', async () => {
@@ -2278,7 +2277,7 @@ suite('UpdatingElement', () => {
     }
     customElements.define(generateElementName(), A);
     const a = new A();
-    document.body.appendChild(a);
+    container.appendChild(a);
     await a.updateComplete;
     assert.equal(a.updatedFoo, 5);
     shouldThrow = true;
@@ -2297,7 +2296,6 @@ suite('UpdatingElement', () => {
     await a.updateComplete;
     assert.equal(a.foo, 20);
     assert.equal(a.updatedFoo, 20);
-    document.body.removeChild(a);
   });
 
   test('exceptions in `shouldUpdate` throw but do not prevent further updates', async () => {
@@ -2320,7 +2318,7 @@ suite('UpdatingElement', () => {
     }
     customElements.define(generateElementName(), A);
     const a = new A();
-    document.body.appendChild(a);
+    container.appendChild(a);
     await a.updateComplete;
     assert.equal(a.updatedFoo, 5);
     shouldThrow = true;
@@ -2339,7 +2337,6 @@ suite('UpdatingElement', () => {
     await a.updateComplete;
     assert.equal(a.foo, 20);
     assert.equal(a.updatedFoo, 20);
-    document.body.removeChild(a);
   });
 
   test('exceptions in `performUpdate` throw but do not prevent further updates', async () => {
@@ -2366,7 +2363,7 @@ suite('UpdatingElement', () => {
     }
     customElements.define(generateElementName(), A);
     const a = new A();
-    document.body.appendChild(a);
+    container.appendChild(a);
     await a.updateComplete;
     assert.equal(a.updatedFoo, 5);
     shouldThrow = true;
@@ -2385,6 +2382,5 @@ suite('UpdatingElement', () => {
     await a.updateComplete;
     assert.equal(a.foo, 20);
     assert.equal(a.updatedFoo, 20);
-    document.body.removeChild(a);
   });
 });

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -212,7 +212,7 @@ suite('LitElement', () => {
     }
     customElements.define(generateElementName(), A);
     const a = new A();
-    document.body.appendChild(a);
+    container.appendChild(a);
     await a.updateComplete;
     assert.equal(a.shadowRoot!.textContent, '5');
     shouldThrow = true;
@@ -231,6 +231,5 @@ suite('LitElement', () => {
     await a.updateComplete;
     assert.equal(a.foo, 20);
     assert.equal(a.shadowRoot!.textContent, '20');
-    document.body.removeChild(a);
   });
 });

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {html, LitElement} from '../lit-element.js';
+import {html, LitElement, property} from '../lit-element.js';
 
 import {generateElementName, stripExpressionDelimeters} from './test-helpers.js';
 
@@ -193,5 +193,44 @@ suite('LitElement', () => {
 
   test('adds a version number', () => {
     assert.equal(window['litElementVersions'].length, 1);
+  });
+
+  test('exceptions in `render` throw but do not prevent further updates', async () => {
+    let shouldThrow = false;
+    class A extends LitElement {
+
+      @property() foo = 5;
+      updatedFoo = 0;
+
+      render() {
+        if (shouldThrow) {
+          throw new Error('test error');
+        }
+        return html`${this.foo}`;
+      }
+
+    }
+    customElements.define(generateElementName(), A);
+    const a = new A();
+    document.body.appendChild(a);
+    await a.updateComplete;
+    assert.equal(a.shadowRoot!.textContent, '5');
+    shouldThrow = true;
+    a.foo = 10;
+    let threw = false;
+    try {
+      await a.updateComplete;
+    } catch (e) {
+      threw = true;
+    }
+    assert.isTrue(threw);
+    assert.equal(a.foo, 10);
+    assert.equal(a.shadowRoot!.textContent, '5');
+    shouldThrow = false;
+    a.foo = 20;
+    await a.updateComplete;
+    assert.equal(a.foo, 20);
+    assert.equal(a.shadowRoot!.textContent, '20');
+    document.body.removeChild(a);
   });
 });


### PR DESCRIPTION
Fixes #262.

Catch exceptions during update and ensure the element marks itself as finished updating.

Note, this change also ensures the `updateComplete` promise is rejected if there's an exception during update.