### PR TITLE
Ensure attribute reflected from property is correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * `LitElement.renderRoot` is now `public readonly` instead of `protected`.
 
 ### Fixed
+* A reflecting property set immediately after a corresponding attribute
+now reflects properly ([#592](https://github.com/Polymer/lit-element/issues/592)).
 * Properties annotated with the `@query` and `@queryAll` decorators will now
   survive property renaming optimizations when used with tsickle and Closure JS
   Compiler.

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -586,7 +586,6 @@ export abstract class UpdatingElement extends HTMLElement {
           ctor._classProperties!.get(name) || defaultPropertyDeclaration;
       if (ctor._valueHasChanged(
               this[name as keyof this], oldValue, options.hasChanged)) {
-        // Track old value when changing.
         if (!this._changedProperties.has(name)) {
           this._changedProperties.set(name, oldValue);
         }
@@ -601,8 +600,8 @@ export abstract class UpdatingElement extends HTMLElement {
           }
           this._reflectingProperties.set(name, options);
         }
-        // Abort the request if the property should not be considered changed.
       } else {
+        // Abort the request if the property should not be considered changed.
         shouldRequestUpdate = false;
       }
     }

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -2219,4 +2219,32 @@ suite('UpdatingElement', () => {
     await a.updateComplete;
     assert.equal(a.updatedCalledCount, 1);
   });
+
+  test('property reflects after setting attribute in same update cycle', async () => {
+    class A extends UpdatingElement {
+
+      foo?: boolean;
+      bar?: string;
+
+      static get properties() {
+        return {
+          foo: {type: Boolean, reflect: true},
+          bar: {type: String, reflect: true}
+        };
+      }
+
+    }
+    customElements.define(generateElementName(), A);
+    const a = new A();
+    container.appendChild(a);
+    a.setAttribute('foo', '');
+    a.removeAttribute('foo');
+    a.foo = true;
+    await a.updateComplete;
+    assert.isTrue(a.hasAttribute('foo'));
+    a.setAttribute('bar', 'hi');
+    a.bar = 'yo';
+    await a.updateComplete;
+    assert.equal(a.getAttribute('bar'), 'yo');
+  });
 });


### PR DESCRIPTION
Fixes #592. Ensures a reflecting property set immediately after a corresponding attribute reflects correctly.