### PR TITLE
docs: fix included code snippets for named slots in templates

### DIFF
--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -289,13 +289,13 @@ _index.html_
 _my-element.js_
 
 ```js
-{% include project.html folder="projects/docs/templates/namedslots/my-element.js" %}
+{% include projects/docs/templates/namedslots/my-element.js %}
 ```
 
 _index.html_
 
 ```html
-{% include project.html folder="projects/docs/templates/namedslots/index.html" %}
+{% include projects/docs/templates/namedslots/index.html %}
 ```
 
 {% include project.html folder="docs/templates/namedslots" openFile="my-element.js" %}


### PR DESCRIPTION
The example snippets in the section on *named slots* where showing the code for a `<stack-blitz>` custom element instead of displaying the example code.

I figured, this was probably a copy & paste glitch (from duplicating a "launch code editor" button), that even I might be able to solve.

### Reference Issue
Solves part of issue #352, precisely [this part](https://github.com/Polymer/lit-element/issues/352#issuecomment-446773772).
