### PR TITLE
feat: allow JavaScript numbers in css template literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    PRs should document their user-visible changes (if any) in the
    Unreleased section, uncommenting the header as necessary.
 -->
-<!-- ### Added -->
+### Added
+* css tagged template literals now allow numbers to be used in expressions ([#488](https://github.com/Polymer/lit-element/issues/488)).
+
 <!-- ### Changed -->
 <!-- ### Removed -->
 <!-- ### Fixed -->

--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -60,9 +60,11 @@ export const unsafeCSS = (value: unknown) => {
   return new CSSResult(String(value), constructionToken);
 };
 
-const textFromCSSResult = (value: CSSResult) => {
+const textFromCSSResult = (value: CSSResult | number) => {
   if (value instanceof CSSResult) {
     return value.cssText;
+  } else if (typeof value === 'number') {
+    return value;
   } else {
     throw new Error(
         `Value passed to 'css' function must be a 'css' function result: ${
@@ -77,7 +79,7 @@ const textFromCSSResult = (value: CSSResult) => {
  * used. To incorporate non-literal values `unsafeCSS` may be used inside a
  * template string part.
  */
-export const css = (strings: TemplateStringsArray, ...values: CSSResult[]) => {
+export const css = (strings: TemplateStringsArray, ...values: (CSSResult | number)[]) => {
   const cssText = values.reduce(
       (acc, v, idx) => acc + textFromCSSResult(v) + strings[idx + 1],
       strings[0]);

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -461,6 +461,13 @@ suite('Static get styles', () => {
     });
   });
 
+  test('`css` allows real JavaScript numbers', async () => {
+    const spacer = 2;
+
+    const result = css`div { margin: ${spacer * 2}px; }`;
+    assert.equal(result.cssText, 'div { margin: 4px; }');
+  });
+
   test('`CSSResult` cannot be constructed', async () => {
     // Note, this is done for security, instead use `css` or `unsafeCSS`
     assert.throws(() => {


### PR DESCRIPTION
This allows for real JavaScript numbers within the css tagged template literal.

### Reference Issue
closes: #488 