### PR TITLE
[docs] Remove z-index on alert style

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -417,7 +417,6 @@ article ol li {
 
 .alert {
   position: relative;
-  z-index: -1;
   margin: 24px 0;
   padding: 1px 20px 1px 56px;
   box-shadow: 0 0 2px #ccc;


### PR DESCRIPTION
Fixes #635. Don't see a reason why `z-index: -1` needs to be there.

Staged at https://20190328t150824-dot-polymer-lit-element.appspot.com/guide/styles

