### PR TITLE
removing unnecessary closing div tag

### DIFF
--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -55,8 +55,6 @@ The styles in the static `styles` property are evaluated once only and applied t
 
 If you don't want to use custom properties, you can define per-instance styles in a `<style>` element inside shadow DOM. See the section on [Defining your styles in a style element](#styleelement) for more information.
 
-</div>
-
 To define a static `styles` property:
 
 1.  Import the `css` helper function from the `lit-element` module:


### PR DESCRIPTION
This extra `</div>` is visible in the public docs here:
https://lit-element.polymer-project.org/guide/styles

Probably an artifact from an old `<div class="alert alert-info">`?

<img width="696" alt="Screen Shot 2019-04-12 at 4 26 44 PM" src="https://user-images.githubusercontent.com/5491151/56064344-cc18a200-5d3f-11e9-9d22-f8bcc40fb34c.png">

