### PR TITLE
Fix TypeScript configuration in publish docs

### DIFF
--- a/docs/_guide/publish.md
+++ b/docs/_guide/publish.md
@@ -37,10 +37,10 @@ The following JSON sample is a partial tsconfig.json that uses recommended optio
 
 ```json
   "compilerOptions": {
-    "target": "ES2017",
-    "module": "ES2017",
+    "target": "es2017",
+    "module": "es2015",
     "moduleResolution": "node",
-    "lib": ["ES2017", "DOM"],
+    "lib": ["es2017", "dom"],
     "experimentalDecorators": true
   }
 ```


### PR DESCRIPTION
`tsconfig.json` does not accept a value of `"es2017"` for `module`. Its schema also specifies allowed values in all
lowercase, so `es2015` is valid but `ES2015` is invalid (though the latter is accepted by the runtime).
  
Fixes #574.