### PR TITLE
Adds documentation on how to use custom accessors with  @property decorator

### DIFF
--- a/docs/_guide/properties.md
+++ b/docs/_guide/properties.md
@@ -415,6 +415,22 @@ The setters that LitElement generates automatically call `requestUpdate`. If you
 {% include projects/properties/customsetter/my-element.js %}
 ```
 
+If you want to use your own property accessor with the `@property` decorator, you can achieve this by putting the decorator on the getter:
+```ts
+set myProp(value) {
+  const oldValue = this.myProp;
+  // Implement setter logic here...
+  this.requestUpdate('myProp', oldValue);
+}
+@property({ type: String })
+get myProp() { ... }
+
+...
+
+// Later, set the property
+this.myProp = 'hi'; // Invokes your accessor
+```
+
 ### Prevent LitElement from generating a property accessor {#accessors-noaccessor}
 
 In rare cases, a subclass may need to change or add property options for a property that exists on its superclass.

--- a/docs/_guide/properties.md
+++ b/docs/_guide/properties.md
@@ -417,20 +417,19 @@ The setters that LitElement generates automatically call `requestUpdate`. If you
 
 If you want to use your own property accessor with the `@property` decorator, you can achieve this by putting the decorator on the getter:
 ```ts
-set myProp(value) {
-  const oldValue = this.myProp;
-  // Implement setter logic here...
-  this.requestUpdate('myProp', oldValue);
-}
-@property({ type: String })
-get myProp() { ... }
+   _myProp: string = '';
 
-...
-
-// Later, set the property
-this.myProp = 'hi'; // Invokes your accessor
+  @property({ type: String })
+  public get myProp(): string {
+    return this._myProp;
+  }
+  public set myProp(value: string) {
+    const oldValue = this.myProp;
+    this._myProp = value;
+    this.requestUpdate('myProp', oldValue);
+  }
 ```
-
+As you can see this works almost exactly like `static get properties()`, except the property declaration goes on the getter.
 ### Prevent LitElement from generating a property accessor {#accessors-noaccessor}
 
 In rare cases, a subclass may need to change or add property options for a property that exists on its superclass.

--- a/docs/_includes/projects/properties/declaretypescript/my-element.ts
+++ b/docs/_includes/projects/properties/declaretypescript/my-element.ts
@@ -18,4 +18,3 @@ export class MyElement extends LitElement {
     `;
   }
 }
-customElements.define('my-element', MyElement);


### PR DESCRIPTION
This adds an example to the properties guide that for custom accessors the `@property` decorator can be put on the getter. Closes #519.