### PR TITLE
fixes link to css-properties

### DIFF
--- a/docs/_guide/styles.md
+++ b/docs/_guide/styles.md
@@ -48,7 +48,7 @@ LitElement lets you define static styles that apply to all instances of a compon
 
 We recommend using static styles for optimal performance. LitElement uses [Constructable Stylesheets](https://wicg.github.io/construct-stylesheets/) in browsers that support it, with a fallback for browsers that don't. Constructable Stylesheets allow the browser to parse styles exactly once and reuse the resulting Stylesheet object for maximum efficiency.
 
-The styles in the static `styles` property are evaluated once only and applied to all instances of the element. You can modify styles per element instance by using [CSS custom properties](#cssprops):
+The styles in the static `styles` property are evaluated once only and applied to all instances of the element. You can modify styles per element instance by using [CSS custom properties](#css-properties):
 
 *   The element **developer** defines a style rule inside shadow DOM that uses CSS variables to apply a custom CSS property to a particular style property.
 *   The element **consumer** defines the value of the custom CSS property outside shadow DOM in a CSS rule that is inherited by the host element.


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->

Hello,

The docs chapter [Define styles in a static styles property](https://lit-element.polymer-project.org/guide/styles#static-styles) has a link [CSS custom properties](https://lit-element.polymer-project.org/guide/styles#cssprops). I assume it should target [Custom CSS Properties](https://lit-element.polymer-project.org/guide/styles#css-properties)

![2019-05-29_13-40-58_link](https://user-images.githubusercontent.com/4787651/58555141-03bcaa00-8219-11e9-88b5-1d8532fe2b96.png)

_For this is a minor change, I took the courage to skip creating an issue, even though this is described in the contribution-guide-lines._ :pray:

# Compare
- broken link (current): https://lit-element.polymer-project.org/guide/styles#cssprops
- updated link (this PR): https://lit-element.polymer-project.org/guide/styles#css-properties
