### PR TITLE
Delegate updateComplete getter to getUpdateComplete method for TS ES5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- ### Added -->
-<!-- ### Changed -->
+### Changed
+* Elements should now override the new `getUpdateComplete` method instead of the `updateComplete` getter, for compatibility with TypeScript ES5 output, which does not support calling a superclass getter (e.g.`super.updateComplete.then(...)`) due to [TypeScript#338](https://github.com/microsoft/TypeScript/issues/338).
 <!-- ### Removed -->
 ### Fixed
 * Fixed compatibility with Closure JS Compiler optimizations relating to static properties ([#732](https://github.com/Polymer/lit-element/issues/732)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 <!-- ### Added -->
 ### Changed
-* Elements should now override the new `getUpdateComplete` method instead of the `updateComplete` getter, for compatibility with TypeScript ES5 output, which does not support calling a superclass getter (e.g.`super.updateComplete.then(...)`) due to [TypeScript#338](https://github.com/microsoft/TypeScript/issues/338).
+* Elements should now override the new `_getUpdateComplete` method instead of the `updateComplete` getter, for compatibility with TypeScript ES5 output, which does not support calling a superclass getter (e.g.`super.updateComplete.then(...)`) due to [TypeScript#338](https://github.com/microsoft/TypeScript/issues/338).
 <!-- ### Removed -->
 ### Fixed
 * Fixed compatibility with Closure JS Compiler optimizations relating to static properties ([#732](https://github.com/Polymer/lit-element/issues/732)).

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -737,14 +737,14 @@ export abstract class UpdatingElement extends HTMLElement {
    * `super.updateComplete` then any subsequent state.
    *
    * IMPORTANT: Do not override this getter directly. Override the
-   * `getUpdateComplete` method instead (see that method's description for more
-   * information).
+   * `_getUpdateComplete` method instead (see that method's description for
+   * more information).
    *
    * @returns {Promise} The Promise returns a boolean that indicates if the
    * update resolved without triggering another update.
    */
   get updateComplete() {
-    return this.getUpdateComplete();
+    return this._getUpdateComplete();
   }
 
   /**
@@ -758,12 +758,12 @@ export abstract class UpdatingElement extends HTMLElement {
    *
    *   class MyElement extends LitElement {
    *     ...
-   *     getUpdateComplete() {
-   *       return super.getUpdateComplete().then(this.myWorkIsDone);
+   *     _getUpdateComplete() {
+   *       return super._getUpdateComplete().then(this.myWorkIsDone);
    *     }
    *   }
    */
-  protected getUpdateComplete() {
+  protected _getUpdateComplete() {
     return this._updatePromise;
   }
 

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -736,10 +736,34 @@ export abstract class UpdatingElement extends HTMLElement {
    * rendered element before fulfilling this Promise. To do this, first await
    * `super.updateComplete` then any subsequent state.
    *
+   * IMPORTANT: Do not override this getter directly. Override the
+   * `getUpdateComplete` method instead (see that method's description for more
+   * information).
+   *
    * @returns {Promise} The Promise returns a boolean that indicates if the
    * update resolved without triggering another update.
    */
   get updateComplete() {
+    return this.getUpdateComplete();
+  }
+
+  /**
+   * Override point for the `updateComplete` promise.
+   *
+   * It is not safe to override the `updateComplete` getter directly due to a
+   * limitation in TypeScript which means it is not possible to call a
+   * superclass getter (e.g. `super.updateComplete.then(...)`) when the target
+   * language is ES5 (https://github.com/microsoft/TypeScript/issues/338).
+   * This method should be overridden instead. For example:
+   *
+   *   class MyElement extends LitElement {
+   *     ...
+   *     getUpdateComplete() {
+   *       return super.getUpdateComplete().then(this.myWorkIsDone);
+   *     }
+   *   }
+   */
+  protected getUpdateComplete() {
     return this._updatePromise;
   }
 


### PR DESCRIPTION
When the target language is ES5, TypeScript does not support calling a superclass getter, which means it is not possible (or at least very awkward) to override the `updateComplete` getter in an element (because a call like `super.updateComplete.then(...)` will not compile). See https://github.com/microsoft/TypeScript/issues/338.

We now delegate the `updateComplete` getter to a new `_getUpdateComplete` method, which can be safely overriden by users. A little awkward, but seemed like the least bad solution we could think of.

See also https://github.com/material-components/material-components-web-components/pull/207 which tried to work around this issue.