### PR TITLE
Use link element with object URL to style in browsers that do not support adoptedStyleSheets

### DIFF
--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -17,6 +17,7 @@ const constructionToken = Symbol();
 
 export class CSSResult {
   _styleSheet?: CSSStyleSheet|null;
+  _objectURL?: string;
 
   readonly cssText: string;
 
@@ -42,6 +43,14 @@ export class CSSResult {
       }
     }
     return this._styleSheet;
+  }
+
+  get objectURL(): string {
+    if (this._objectURL === undefined) {
+      const blob = new Blob([this.cssText], {type: 'text/css'});
+      this._objectURL = URL.createObjectURL(blob);
+    }
+    return this._objectURL;
   }
 
   toString(): string {

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -228,9 +228,10 @@ export class LitElement extends UpdatingElement {
     if (this._needsShimAdoptedStyleSheets) {
       this._needsShimAdoptedStyleSheets = false;
       (this.constructor as typeof LitElement)._styles!.forEach((s) => {
-        const style = document.createElement('style');
-        style.textContent = s.cssText;
-        this.renderRoot.appendChild(style);
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = s.objectURL;
+        this.renderRoot.appendChild(link);
       });
     }
   }


### PR DESCRIPTION
Uses a link element with href pointing to a object URL instead of a style element for browsers that supports native shadow dom but do not implement `adoptedStyleSheets`

### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #761 