### PR TITLE
Update doc references for ?checked

### DIFF
--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -140,7 +140,7 @@ You can insert JavaScript expressions as placeholders for HTML text content, att
 
 * Text content: `<p>${...}</p>`
 * Attribute: `<p id="${...}"></p>`
-* Boolean attribute: `?checked="${...}"`
+* Boolean attribute: `?disabled="${...}"`
 * Property: `.value="${...}"`
 * Event handler: `@event="${...}"`
 
@@ -168,10 +168,10 @@ Attribute values are always strings, so an attribute binding should return a val
 
 #### Bind to a boolean attribute
 
-Bind `prop3` to a boolean attribute: 
+Bind `prop3` to a boolean attribute:
 
 ```js
-html`<input type="checkbox" ?checked="${this.prop3}">i like pie</input>`
+html`<input type="text" ?disabled="${this.prop3}">`
 ```
 
 Boolean attributes are added if the expression evaluates to a truthy value, and removed if it evaluates to a falsy value.
@@ -446,7 +446,7 @@ html`${this.myBool?html`<p>foo</p>`:html`<p>bar</p>`}`;
 html`<p id="${...}">`;
 
 // Boolean attribute
-html`<input type="checkbox" ?checked="${...}">`;
+html`<input type="text" ?disabled="${...}">`;
 
 // Property
 html`<input .value="${...}">`;

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -20,7 +20,7 @@ class MyElement extends LitElement {
 }
 ```
 
-* Write your template in HTML inside a JavaScript template literal by enclosing the raw HTML in back-ticks (<code>``</code>). 
+* Write your template in HTML inside a JavaScript template literal by enclosing the raw HTML in back-ticks (<code>``</code>).
 
 * Tag your template literal with the `html` helper function, so that `render` returns a lit-html `TemplateResult`.
 
@@ -45,7 +45,7 @@ To do this, make sure the `render` function:
 * Only depends on the element's properties.
 * Returns the same result when given the same property values.
 
-Also, avoid making DOM updates outside of `render`. Instead, express the element's template as a function of its state, and capture its state in properties. 
+Also, avoid making DOM updates outside of `render`. Instead, express the element's template as a function of its state, and capture its state in properties.
 
 The following code uses inefficient DOM manipulation:
 
@@ -99,8 +99,8 @@ static get properties() {
   return { myProp: String };
 }
 ...
-render() { 
-  return html`<p>${this.myProp}</p>`; 
+render() {
+  return html`<p>${this.myProp}</p>`;
 }
 ```
 
@@ -140,7 +140,7 @@ You can insert JavaScript expressions as placeholders for HTML text content, att
 
 * Text content: `<p>${...}</p>`
 * Attribute: `<p id="${...}"></p>`
-* Boolean attribute: `?checked="${...}"`
+* Boolean attribute: `?disabled="${...}"`
 * Property: `.value="${...}"`
 * Event handler: `@event="${...}"`
 
@@ -168,10 +168,10 @@ Attribute values are always strings, so an attribute binding should return a val
 
 #### Bind to a boolean attribute
 
-Bind `prop3` to a boolean attribute: 
+Bind `prop3` to a boolean attribute:
 
 ```js
-html`<input type="checkbox" ?checked="${this.prop3}">i like pie</input>`
+html`<input type="text" ?disabled="${this.prop3}">i like pie</input>`
 ```
 
 Boolean attributes are added if the expression evaluates to a truthy value, and removed if it evaluates to a falsy value.
@@ -181,7 +181,7 @@ Boolean attributes are added if the expression evaluates to a truthy value, and 
 Bind `prop4` to a property:
 
 ```js
-html`<input type="checkbox" .value="${this.prop4}"/>`
+html`<input type="text" .value="${this.prop4}"/>`
 ```
 
 #### Bind to an event handler
@@ -218,7 +218,7 @@ By default, if a custom element has light DOM children in HTML, they do not rend
 </my-element>
 ```
 
-You can make them render using the [`<slot>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot). 
+You can make them render using the [`<slot>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot).
 
 #### Use the `slot` element
 
@@ -387,7 +387,7 @@ By default, LitElement creates an open `shadowRoot` and renders inside it, produ
     <p>child 2</p>
 ```
 
-To customize a component's render root, implement `createRenderRoot` and return the node you want the template to render into. 
+To customize a component's render root, implement `createRenderRoot` and return the node you want the template to render into.
 
 For example, to render the template into the main DOM tree as your element's light DOM:
 
@@ -408,7 +408,7 @@ class LightDom extends LitElement {
   }
   createRenderRoot() {
   /**
-   * Render template in light DOM. Note that shadow DOM features like 
+   * Render template in light DOM. Note that shadow DOM features like
    * encapsulated CSS are unavailable.
    */
     return this;
@@ -432,7 +432,7 @@ render() { return html`<p>template</p>`; }
 // Property
 html`<p>${this.myProp}</p>`;
 
-// Loop 
+// Loop
 html`${this.myArray.map(i => html`<li>${i}</li>`)}`;
 
 // Conditional
@@ -446,12 +446,12 @@ html`${this.myBool?html`<p>foo</p>`:html`<p>bar</p>`}`;
 html`<p id="${...}">`;
 
 // Boolean attribute
-html`<input type="checkbox" ?checked="${...}">`;
+html`<input type="text" ?disabled="${...}">`;
 
 // Property
 html`<input .value="${...}">`;
 
-// Event handler 
+// Event handler
 html`<button @click="${this.doStuff}"></button>`;
 ```
 

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -20,7 +20,7 @@ class MyElement extends LitElement {
 }
 ```
 
-* Write your template in HTML inside a JavaScript template literal by enclosing the raw HTML in back-ticks (<code>``</code>).
+* Write your template in HTML inside a JavaScript template literal by enclosing the raw HTML in back-ticks (<code>``</code>). 
 
 * Tag your template literal with the `html` helper function, so that `render` returns a lit-html `TemplateResult`.
 
@@ -45,7 +45,7 @@ To do this, make sure the `render` function:
 * Only depends on the element's properties.
 * Returns the same result when given the same property values.
 
-Also, avoid making DOM updates outside of `render`. Instead, express the element's template as a function of its state, and capture its state in properties.
+Also, avoid making DOM updates outside of `render`. Instead, express the element's template as a function of its state, and capture its state in properties. 
 
 The following code uses inefficient DOM manipulation:
 
@@ -99,8 +99,8 @@ static get properties() {
   return { myProp: String };
 }
 ...
-render() {
-  return html`<p>${this.myProp}</p>`;
+render() { 
+  return html`<p>${this.myProp}</p>`; 
 }
 ```
 
@@ -140,7 +140,7 @@ You can insert JavaScript expressions as placeholders for HTML text content, att
 
 * Text content: `<p>${...}</p>`
 * Attribute: `<p id="${...}"></p>`
-* Boolean attribute: `?disabled="${...}"`
+* Boolean attribute: `?checked="${...}"`
 * Property: `.value="${...}"`
 * Event handler: `@event="${...}"`
 
@@ -168,10 +168,10 @@ Attribute values are always strings, so an attribute binding should return a val
 
 #### Bind to a boolean attribute
 
-Bind `prop3` to a boolean attribute:
+Bind `prop3` to a boolean attribute: 
 
 ```js
-html`<input type="text" ?disabled="${this.prop3}">i like pie</input>`
+html`<input type="checkbox" ?checked="${this.prop3}">i like pie</input>`
 ```
 
 Boolean attributes are added if the expression evaluates to a truthy value, and removed if it evaluates to a falsy value.
@@ -181,7 +181,7 @@ Boolean attributes are added if the expression evaluates to a truthy value, and 
 Bind `prop4` to a property:
 
 ```js
-html`<input type="text" .value="${this.prop4}"/>`
+html`<input type="checkbox" .value="${this.prop4}"/>`
 ```
 
 #### Bind to an event handler
@@ -218,7 +218,7 @@ By default, if a custom element has light DOM children in HTML, they do not rend
 </my-element>
 ```
 
-You can make them render using the [`<slot>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot).
+You can make them render using the [`<slot>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot). 
 
 #### Use the `slot` element
 
@@ -387,7 +387,7 @@ By default, LitElement creates an open `shadowRoot` and renders inside it, produ
     <p>child 2</p>
 ```
 
-To customize a component's render root, implement `createRenderRoot` and return the node you want the template to render into.
+To customize a component's render root, implement `createRenderRoot` and return the node you want the template to render into. 
 
 For example, to render the template into the main DOM tree as your element's light DOM:
 
@@ -408,7 +408,7 @@ class LightDom extends LitElement {
   }
   createRenderRoot() {
   /**
-   * Render template in light DOM. Note that shadow DOM features like
+   * Render template in light DOM. Note that shadow DOM features like 
    * encapsulated CSS are unavailable.
    */
     return this;
@@ -432,7 +432,7 @@ render() { return html`<p>template</p>`; }
 // Property
 html`<p>${this.myProp}</p>`;
 
-// Loop
+// Loop 
 html`${this.myArray.map(i => html`<li>${i}</li>`)}`;
 
 // Conditional
@@ -446,12 +446,12 @@ html`${this.myBool?html`<p>foo</p>`:html`<p>bar</p>`}`;
 html`<p id="${...}">`;
 
 // Boolean attribute
-html`<input type="text" ?disabled="${...}">`;
+html`<input type="checkbox" ?checked="${...}">`;
 
 // Property
 html`<input .value="${...}">`;
 
-// Event handler
+// Event handler 
 html`<button @click="${this.doStuff}"></button>`;
 ```
 

--- a/docs/_includes/projects/docs/templates/databinding/my-element.js
+++ b/docs/_includes/projects/docs/templates/databinding/my-element.js
@@ -27,13 +27,13 @@ class MyElement extends LitElement {
       <!-- boolean attribute binding -->
       <div>
         boolean attribute binding
-        <input type="checkbox" ?checked="${this.prop3}"/>
+        <input type="text" ?disabled="${this.prop3}"/>
       </div>
 
       <!-- property binding -->
       <div>
         property binding
-        <input type="checkbox" .value="${this.prop4}"/>
+        <input type="text" .value="${this.prop4}"/>
       </div>
 
       <!-- event handler binding -->

--- a/docs/_includes/projects/docs/templates/databinding/my-element.js
+++ b/docs/_includes/projects/docs/templates/databinding/my-element.js
@@ -27,13 +27,13 @@ class MyElement extends LitElement {
       <!-- boolean attribute binding -->
       <div>
         boolean attribute binding
-        <input type="text" ?disabled="${this.prop3}"/>
+        <input type="checkbox" ?checked="${this.prop3}"/>
       </div>
 
       <!-- property binding -->
       <div>
         property binding
-        <input type="text" .value="${this.prop4}"/>
+        <input type="checkbox" .value="${this.prop4}"/>
       </div>
 
       <!-- event handler binding -->


### PR DESCRIPTION
This removes the `?checked` reference in the docs in favor of `?disabled`, since this is a cleaner representation of a boolean attribute since there are no user interactions that can set the property. 
