### PR TITLE
[Docs site] Add z-index on side-nav style

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -343,6 +343,7 @@ section p {
   width: 240px;
   font-size: 14px;
   font-weight: 500;
+  z-index: 1;
 }
 
 .side-nav > #toggleNavButton {


### PR DESCRIPTION
Set z-index on side-nav style to prevent it from overlapping with the alert style in small screen devices

