### PR TITLE
Add optional use of generics on PropertyValues

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -127,7 +127,12 @@ type PropertyDeclarationMap = Map<PropertyKey, PropertyDeclaration>;
 
 type AttributeMap = Map<string, PropertyKey>;
 
-export type PropertyValues = Map<PropertyKey, unknown>;
+/**
+ * Map of changed properties with old values. Takes an optional generic
+ * interface corresponding to the declared element properties.
+ */
+// tslint:disable-next-line:no-any
+export type PropertyValues<T = any> = keyof T extends PropertyKey ? Map<keyof T, unknown> : never;
 
 export const defaultConverter: ComplexAttributeConverter = {
 


### PR DESCRIPTION
### Reference Issue

Fixes #744

### What I did

Add _optional_ use of generics on `PropertyValues` to allow Typescript to type-check/hint within the `firstUpdated` and `updated` methods. Because using the generics is optional, this is not a braking change.

To reiterate what I described in the issue initially: 


**Pros**
- It's opt-in.
- It's backwards compatible with the current definition.
- `props.has('unknownProp')` wouldn't type-check when using `PropertyValues<this>`.
- `props.has('notAnAtProp')` wouldn't type-check when using `PropertyValues<ImplementedInterface>` (see usage example below).

**Cons**
- People may expect `PropertyValues<this>` to infer and type-check `@properties`, even though the expected behavior is that it won't until applying `PropertyValues<ImplementedInterface>`.


### Usage 

All examples of current usage of `PropertyValues` (without generics) are still applicable. Below example usage with generics.

```ts
interface MyElementProps {
  hello: string;
}

@customElement('my-element')
export class MyElement extends LitElement implements MyElementProps {

  @property({ type: String })
  hello = 'hello';

  otherProp = true;

  updated(changedProperties: PropertyValues<MyElementProps>) {
    // Will pass type-checking because `hello` is a known property
    if (changedProperties.has('hello')) { /** */ }

    // Won't pass type-checking because `goodbye` isn't a known property
    if (changedProperties.has('goodbye')) { /** */ }

    // Won't pass type-checking because `otherProp` isn't a known property within MyElementProps 
    if (changedProperties.has('otherProp')) { /** */ }
  }

  render() {
    return html`<p>${this.hello}</p>`;
  }
}
```
