### PR TITLE
Native cssstylesheet

### DIFF
--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -13,7 +13,7 @@ found at http://polymer.github.io/PATENTS.txt
  * Whether the current browser supports `adoptedStyleSheets`.
  */
 export const supportsAdoptingStyleSheets = (window.ShadowRoot) &&
-    (window.ShadyCSS === undefined) &&
+    (window.ShadyCSS === undefined || window.ShadyCSS.nativeShadow) &&
     ('adoptedStyleSheets' in Document.prototype) &&
     ('replace' in CSSStyleSheet.prototype);
 

--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -13,7 +13,7 @@ found at http://polymer.github.io/PATENTS.txt
  * Whether the current browser supports `adoptedStyleSheets`.
  */
 export const supportsAdoptingStyleSheets = (window.ShadowRoot) &&
-    ('adoptedStyleSheets' in ShadowRoot.prototype) &&
+    ('adoptedStyleSheets' in Document.prototype) &&
     ('replace' in CSSStyleSheet.prototype);
 
 const constructionToken = Symbol();

--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -12,8 +12,7 @@ found at http://polymer.github.io/PATENTS.txt
 /**
  * Whether the current browser supports `adoptedStyleSheets`.
  */
-export const supportsAdoptingStyleSheets =
-    (window.ShadowRoot) &&
+export const supportsAdoptingStyleSheets = (window.ShadowRoot) &&
     ('adoptedStyleSheets' in ShadowRoot.prototype) &&
     ('replace' in CSSStyleSheet.prototype);
 

--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -12,7 +12,7 @@ found at http://polymer.github.io/PATENTS.txt
 /**
  * Whether the current browser supports `adoptedStyleSheets`.
  */
-export const supportsAdoptingShadowStyleSheets =
+export const supportsAdoptingStyleSheets =
     (window.ShadowRoot) &&
     ('adoptedStyleSheets' in ShadowRoot.prototype) &&
     ('replace' in CSSStyleSheet.prototype);
@@ -37,9 +37,9 @@ export class CSSResult {
   // stylesheets are not created until the first element instance is made.
   get styleSheet(): CSSStyleSheet|null {
     if (this._styleSheet === undefined) {
-      // Note, if `supportsAdoptingShadowStyleSheets` is true then we assume
+      // Note, if `supportsAdoptingStyleSheets` is true then we assume
       // CSSStyleSheet is constructable.
-      if (supportsAdoptingShadowStyleSheets) {
+      if (supportsAdoptingStyleSheets) {
         this._styleSheet = new CSSStyleSheet();
         this._styleSheet.replaceSync(this.cssText);
       } else {

--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -13,6 +13,7 @@ found at http://polymer.github.io/PATENTS.txt
  * Whether the current browser supports `adoptedStyleSheets`.
  */
 export const supportsAdoptingStyleSheets = (window.ShadowRoot) &&
+    (window.ShadyCSS === undefined) &&
     ('adoptedStyleSheets' in Document.prototype) &&
     ('replace' in CSSStyleSheet.prototype);
 

--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -12,8 +12,9 @@ found at http://polymer.github.io/PATENTS.txt
 /**
  * Whether the current browser supports `adoptedStyleSheets`.
  */
-export const supportsAdoptingStyleSheets =
-    ('adoptedStyleSheets' in Document.prototype) &&
+export const supportsAdoptingShadowStyleSheets =
+    (window.ShadowRoot) &&
+    ('adoptedStyleSheets' in ShadowRoot.prototype) &&
     ('replace' in CSSStyleSheet.prototype);
 
 const constructionToken = Symbol();
@@ -28,6 +29,7 @@ export class CSSResult {
       throw new Error(
           'CSSResult is not constructable. Use `unsafeCSS` or `css` instead.');
     }
+
     this.cssText = cssText;
   }
 
@@ -35,9 +37,9 @@ export class CSSResult {
   // stylesheets are not created until the first element instance is made.
   get styleSheet(): CSSStyleSheet|null {
     if (this._styleSheet === undefined) {
-      // Note, if `adoptedStyleSheets` is supported then we assume CSSStyleSheet
-      // is constructable.
-      if (supportsAdoptingStyleSheets) {
+      // Note, if `supportsAdoptingShadowStyleSheets` is supported then we
+      // assume CSSStyleSheet is constructable.
+      if (supportsAdoptingShadowStyleSheets) {
         this._styleSheet = new CSSStyleSheet();
         this._styleSheet.replaceSync(this.cssText);
       } else {

--- a/src/lib/css-tag.ts
+++ b/src/lib/css-tag.ts
@@ -37,8 +37,8 @@ export class CSSResult {
   // stylesheets are not created until the first element instance is made.
   get styleSheet(): CSSStyleSheet|null {
     if (this._styleSheet === undefined) {
-      // Note, if `supportsAdoptingShadowStyleSheets` is supported then we
-      // assume CSSStyleSheet is constructable.
+      // Note, if `supportsAdoptingShadowStyleSheets` is true then we assume
+      // CSSStyleSheet is constructable.
       if (supportsAdoptingShadowStyleSheets) {
         this._styleSheet = new CSSStyleSheet();
         this._styleSheet.replaceSync(this.cssText);

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -107,6 +107,10 @@ export class LitElement extends UpdatingElement {
     }
     // Take care not to call `this.getStyles()` multiple times since this
     // generates new CSSResults each time.
+    // TODO(sorvell): Since we do not cache CSSResults by input, any
+    // shared styles will generate new stylesheet objects, which is wasteful.
+    // This should be addressed when a browser ships constructable
+    // stylesheets.
     const userStyles = this.getStyles();
 
     if (Array.isArray(userStyles)) {
@@ -171,7 +175,7 @@ export class LitElement extends UpdatingElement {
   }
 
   /**
-   * Applies styling to the element shadowRoot using the `static get styles`
+   * Applies styling to the element shadowRoot using the [[`styles`]]
    * property. Styling will apply using `shadowRoot.adoptedStyleSheets` where
    * available and will fallback otherwise. When Shadow DOM is polyfilled,
    * ShadyCSS scopes styles and adds them to the document. When Shadow DOM

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -18,7 +18,7 @@ import {PropertyValues, UpdatingElement} from './lib/updating-element.js';
 export * from './lib/updating-element.js';
 export * from './lib/decorators.js';
 export {html, svg, TemplateResult, SVGTemplateResult} from 'lit-html/lit-html.js';
-import {supportsAdoptingStyleSheets, CSSResult, unsafeCSS, css} from './lib/css-tag.js';
+import {supportsAdoptingStyleSheets, CSSResult, unsafeCSS} from './lib/css-tag.js';
 export * from './lib/css-tag.js';
 
 declare global {

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -152,9 +152,8 @@ export class LitElement extends UpdatingElement {
           // Flatten the cssText from the passed constructible stylesheet. The
           // user might have expected to update their stylesheets over time,
           // but the alternative was a crash.
-          const cssText = Array.prototype.slice.call(s.cssRules).reduce((css, rule) => css + rule.cssText, '');
-              .map((rule) => rule.cssText)
-              .join('');
+          const cssText = Array.prototype.slice.call(s.cssRules)
+              .reduce((css, rule) => css + rule.cssText, '');
           return unsafeCSS(cssText);
         }
       }

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -110,7 +110,7 @@ export class LitElement extends UpdatingElement {
     }
     // Take care not to call `this.getStyles()` multiple times since this
     // generates new CSSResults each time.
-    const userStyles = this.styles!;
+    const userStyles = this.getStyles();
     const work = [];
 
     if (Array.isArray(userStyles)) {

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -82,7 +82,7 @@ export class LitElement extends UpdatingElement {
 
   /**
    * Array of styles to apply to the element. The styles should be defined
-   * using the [[`css`]] tag function.
+   * using the `css` tag function or via constructible stylesheets.
    */
   static styles?: CSSResultOrNative|CSSResultArray;
 
@@ -145,7 +145,7 @@ export class LitElement extends UpdatingElement {
       });
     } else {
       // This is only possible when a user passes a CSSStyleSheet that was
-      // read from a <style> or <link rel="stylesheet"> tag, which are not
+      // obtained from a <style> or <link rel="stylesheet"> tag: these are not
       // constructible stylesheets.
       work.forEach((resultOrNative) => {
         if (resultOrNative instanceof CSSStyleSheet) {

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -143,7 +143,7 @@ export class LitElement extends UpdatingElement {
     // In both cases, the user might have expected to update their stylesheets
     // over time, but the alternative was a crash.
     this._styles = this._styles.map((s) => {
-      if (s instanceof CSSStyleSheet && 
+      if (s instanceof CSSStyleSheet &&
           (s.ownerNode || !supportsAdoptingStyleSheets)) {
         const cssText = Array.prototype.slice.call(s.cssRules)
             .map((rule) => rule.cssText)

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -82,7 +82,7 @@ export class LitElement extends UpdatingElement {
 
   /**
    * Array of styles to apply to the element. The styles should be defined
-   * using the `css` tag function or via constructible stylesheets.
+   * using the [[`css`]] tag function or via constructible stylesheets.
    */
   static styles?: CSSResultOrNative|CSSResultArray;
 

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -152,7 +152,7 @@ export class LitElement extends UpdatingElement {
           // Flatten the cssText from the passed constructible stylesheet. The
           // user might have expected to update their stylesheets over time,
           // but the alternative was a crash.
-          const cssText = Array.prototype.slice.call(s.cssRules)
+          const cssText = Array.prototype.slice.call(s.cssRules).reduce((css, rule) => css + rule.cssText, '');
               .map((rule) => rule.cssText)
               .join('');
           return unsafeCSS(cssText);

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -18,7 +18,7 @@ import {PropertyValues, UpdatingElement} from './lib/updating-element.js';
 export * from './lib/updating-element.js';
 export * from './lib/decorators.js';
 export {html, svg, TemplateResult, SVGTemplateResult} from 'lit-html/lit-html.js';
-import {supportsAdoptingShadowStyleSheets, CSSResult} from './lib/css-tag.js';
+import {supportsAdoptingStyleSheets, CSSResult} from './lib/css-tag.js';
 export * from './lib/css-tag.js';
 
 declare global {
@@ -87,6 +87,11 @@ export class LitElement extends UpdatingElement {
   static styles?: CSSResultOrNative|CSSResultArray;
 
   private static _styles: CSSResult[]|undefined;
+
+  /**
+   * Native CSSStyleSheet to apply to the element. Used over `_styles` when
+   * native support is available.
+   */
   private static _nativeStyles: CSSStyleSheet[]|undefined;
 
   /**
@@ -102,7 +107,7 @@ export class LitElement extends UpdatingElement {
   /** @nocollapse */
   private static _getUniqueStyles() {
     // Only gather styles once per class
-    const property = supportsAdoptingShadowStyleSheets ?
+    const property = supportsAdoptingStyleSheets ?
         JSCompiler_renameProperty('_nativeStyles', this) :
         JSCompiler_renameProperty('_styles', this);
     if (this.hasOwnProperty(property)) {
@@ -135,7 +140,7 @@ export class LitElement extends UpdatingElement {
       work.push(userStyles);
     }
 
-    if (supportsAdoptingShadowStyleSheets) {
+    if (supportsAdoptingStyleSheets) {
       // Convert all CSSResult instances to native CSSStyleSheet.
       this._nativeStyles = work.map((resultOrNative) => {
         if (resultOrNative instanceof CSSResult) {
@@ -194,8 +199,8 @@ export class LitElement extends UpdatingElement {
   }
 
   /**
-   * Applies styling to the element shadowRoot using the private styles
-   * properties. Styling will apply using `shadowRoot.adoptedStyleSheets` where
+   * Applies styling to the element shadowRoot using the `static get styles`
+   * property. Styling will apply using `shadowRoot.adoptedStyleSheets` where
    * available and will fallback otherwise. When Shadow DOM is polyfilled,
    * ShadyCSS scopes styles and adds them to the document. When Shadow DOM
    * is available but `adoptedStyleSheets` is not, styles are appended to the
@@ -203,7 +208,7 @@ export class LitElement extends UpdatingElement {
    * behavior](https://wicg.github.io/construct-stylesheets/#using-constructed-stylesheets).
    */
   protected adoptStyles() {
-    if (supportsAdoptingShadowStyleSheets) {
+    if (supportsAdoptingStyleSheets) {
       (this.renderRoot as ShadowRoot).adoptedStyleSheets =
           (this.constructor as typeof LitElement)._nativeStyles!;
       return;

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -90,12 +90,6 @@ export class LitElement extends UpdatingElement {
   private static _styles: Array<CSSResultOrNative|CSSResult>|undefined;
 
   /**
-   * Native CSSStyleSheet to apply to the element. Used over `_styles` when
-   * native support is available.
-   */
-  // private static _nativeStyles: CSSStyleSheet[]|undefined;
-
-  /**
    * Return the array of styles to apply to the element.
    * Override this method to integrate into a style management system.
    *
@@ -192,7 +186,7 @@ export class LitElement extends UpdatingElement {
     }
     // There are three separate cases here based on Shadow DOM support.
     // (1) shadowRoot polyfilled: use ShadyCSS
-    // (2) shadowRoot.adoptedStyleSheets available: use it (above)
+    // (2) shadowRoot.adoptedStyleSheets available: use it
     // (3) shadowRoot.adoptedStyleSheets polyfilled: append styles after
     // rendering
     if (window.ShadyCSS !== undefined && !window.ShadyCSS.nativeShadow) {

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -35,7 +35,8 @@ declare global {
 
 export type CSSResultOrNative = CSSResult|CSSStyleSheet;
 
-export interface CSSResultArray extends Array<CSSResultOrNative|CSSResultArray> {}
+export interface CSSResultArray extends
+    Array<CSSResultOrNative|CSSResultArray> {}
 
 /**
  * Sentinal value used to avoid calling lit-html's render function when
@@ -86,13 +87,13 @@ export class LitElement extends UpdatingElement {
    */
   static styles?: CSSResultOrNative|CSSResultArray;
 
-  private static _styles: CSSResult[]|undefined;
+  private static _styles: Array<CSSResultOrNative|CSSResult>|undefined;
 
   /**
    * Native CSSStyleSheet to apply to the element. Used over `_styles` when
    * native support is available.
    */
-  private static _nativeStyles: CSSStyleSheet[]|undefined;
+  // private static _nativeStyles: CSSStyleSheet[]|undefined;
 
   /**
    * Return the array of styles to apply to the element.
@@ -107,16 +108,12 @@ export class LitElement extends UpdatingElement {
   /** @nocollapse */
   private static _getUniqueStyles() {
     // Only gather styles once per class
-    const property = supportsAdoptingStyleSheets ?
-        JSCompiler_renameProperty('_nativeStyles', this) :
-        JSCompiler_renameProperty('_styles', this);
-    if (this.hasOwnProperty(property)) {
+    if (this.hasOwnProperty(JSCompiler_renameProperty('_styles', this))) {
       return;
     }
     // Take care not to call `this.getStyles()` multiple times since this
     // generates new CSSResults each time.
     const userStyles = this.getStyles();
-    const work = [];
 
     if (Array.isArray(userStyles)) {
       // De-duplicate styles preserving the _last_ instance in the set.
@@ -125,39 +122,20 @@ export class LitElement extends UpdatingElement {
       // The last item is kept to try to preserve the cascade order with the
       // assumption that it's most important that last added styles override
       // previous styles.
-      const addStyles =
-          (styles: CSSResultArray, set: Set<CSSResultOrNative>): Set<CSSResultOrNative> =>
-              styles.reduceRight(
-                  (set: Set<CSSResultOrNative>, s) =>
-                      // Note: On IE set.add() does not return the set
-                  Array.isArray(s) ? addStyles(s, set) : (set.add(s), set),
-                  set);
+      const addStyles = (styles: CSSResultArray, set: Set<CSSResultOrNative>):
+          Set<CSSResultOrNative> => styles.reduceRight(
+              (set: Set<CSSResultOrNative>, s) =>
+                  // Note: On IE set.add() does not return the set
+              Array.isArray(s) ? addStyles(s, set) : (set.add(s), set),
+              set);
       // Array.from does not work on Set in IE, otherwise return
       // Array.from(addStyles(userStyles, new Set<CSSResult>())).reverse()
       const set = addStyles(userStyles, new Set<CSSResultOrNative>());
-      set.forEach((v) => work.unshift(v));
-    } else if (userStyles !== undefined) {
-      work.push(userStyles);
-    }
-
-    if (supportsAdoptingStyleSheets) {
-      // Convert all CSSResult instances to native CSSStyleSheet.
-      this._nativeStyles = work.map((resultOrNative) => {
-        if (resultOrNative instanceof CSSResult) {
-          return resultOrNative.styleSheet!;
-        }
-        return resultOrNative;
-      });
+      const styles: CSSResultOrNative[] = [];
+      set.forEach((v) => styles.unshift(v));
+      this._styles = styles;
     } else {
-      // This is only possible when a user passes a CSSStyleSheet that was
-      // obtained from a <style> or <link rel="stylesheet"> tag: these are not
-      // constructible stylesheets.
-      work.forEach((resultOrNative) => {
-        if (resultOrNative instanceof CSSStyleSheet) {
-          throw new Error('Can\'t adopt non-constructed stylesheets.');
-        }
-      });
-      this._styles = <CSSResult[]> work;
+      this._styles = userStyles === undefined ? [] : [userStyles];
     }
   }
 
@@ -208,12 +186,6 @@ export class LitElement extends UpdatingElement {
    * behavior](https://wicg.github.io/construct-stylesheets/#using-constructed-stylesheets).
    */
   protected adoptStyles() {
-    if (supportsAdoptingStyleSheets) {
-      (this.renderRoot as ShadowRoot).adoptedStyleSheets =
-          (this.constructor as typeof LitElement)._nativeStyles!;
-      return;
-    }
-
     const styles = (this.constructor as typeof LitElement)._styles!;
     if (styles.length === 0) {
       return;
@@ -226,6 +198,9 @@ export class LitElement extends UpdatingElement {
     if (window.ShadyCSS !== undefined && !window.ShadyCSS.nativeShadow) {
       window.ShadyCSS.ScopingShim!.prepareAdoptedCssText(
           styles.map((s) => s.cssText), this.localName);
+    } else if (supportsAdoptingStyleSheets) {
+      (this.renderRoot as ShadowRoot).adoptedStyleSheets =
+          styles.map((s) => s instanceof CSSStyleSheet ? s : s.styleSheet!);
     } else {
       // This must be done after rendering so the actual style insertion is done
       // in `update`.

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -925,7 +925,7 @@ suite('Static get styles', () => {
 
   // Test this in Shadow DOM without `adoptedStyleSheets` only since it's easily
   // detectable in that case. Look explicitly for no ShadyCSS.
-  const testNativeAdoptedStyleSheets =(window.ShadyCSS === undefined) &&
+  const testNativeAdoptedStyleSheets = (window.ShadyCSS === undefined) &&
       (typeof ShadowRoot === 'function') &&
       ('adoptedStyleSheets' in window.ShadowRoot.prototype);
   (testNativeAdoptedStyleSheets ? test : test.skip)(

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -792,10 +792,16 @@ suite('Static get styles', () => {
 
   test('element class only gathers styles once', async () => {
     const base = generateElementName();
-    let styleCounter = 0;
+    let getStylesCounter = 0;
+    let stylesCounter = 0;
     customElements.define(base, class extends LitElement {
+      static getStyles() {
+        getStylesCounter++;
+        return super.getStyles();
+      }
+
       static get styles() {
-        styleCounter++;
+        stylesCounter++;
         return css`:host {
           border: 10px solid black;
         }`;
@@ -821,7 +827,9 @@ suite('Static get styles', () => {
         '10px',
         'el2 styled correctly');
     assert.equal(
-        styleCounter, 1, 'styles property should only be accessed once');
+        stylesCounter, 1, 'styles property should only be accessed once');
+    assert.equal(
+      getStylesCounter, 1, 'getStyles() should be called once');
   });
 
   test(

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -894,13 +894,13 @@ suite('Static get styles', () => {
   // Test this in Shadow DOM without `adoptedStyleSheets` only since it's easily
   // detectable in that case.
   const testNativeAdoptedStyleSheets =
-      (typeof ShadowRoot === 'object') &&
+      (typeof ShadowRoot === 'function') &&
       ('adoptedStyleSheets' in window.ShadowRoot.prototype);
   (testNativeAdoptedStyleSheets ? test : test.skip)(
       'Can return CSSStyleSheet where adoptedStyleSheets are natively supported',
       async () => {
         const sheet = new CSSStyleSheet();
-        sheet.replaceSync('div { background: red; }');
+        sheet.replaceSync('div { border: 4px solid red; }');
 
         const base = generateElementName();
         customElements.define(base, class extends LitElement {
@@ -916,7 +916,6 @@ suite('Static get styles', () => {
         await (el as LitElement).updateComplete;
         const div = el.shadowRoot!.querySelector('div');
 
-        // FIXME: error to prove this is running
         assert.equal(
           getComputedStyle(div!).getPropertyValue('background').trim(), 'blue');
       });

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -922,10 +922,12 @@ suite('Static get styles', () => {
         const el = document.createElement(base);
         container.appendChild(el);
         await (el as LitElement).updateComplete;
-        const div = el.shadowRoot!.querySelector('div');
-
+        const div = el.shadowRoot!.querySelector('div')!;
         assert.equal(
-          getComputedStyle(div!).getPropertyValue('background').trim(), 'blue');
+            getComputedStyle(div)
+                .getPropertyValue('border-top-width')
+                .trim(),
+            '4px');
       });
 });
 

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -925,7 +925,7 @@ suite('Static get styles', () => {
 
   // Test this in Shadow DOM without `adoptedStyleSheets` only since it's easily
   // detectable in that case. Look explicitly for no ShadyCSS.
-  const testNativeAdoptedStyleSheets = (window.ShadyCSS === undefined) &&
+  const testNativeAdoptedStyleSheets =(window.ShadyCSS === undefined) &&
       (typeof ShadowRoot === 'function') &&
       ('adoptedStyleSheets' in window.ShadowRoot.prototype);
   (testNativeAdoptedStyleSheets ? test : test.skip)(
@@ -951,17 +951,19 @@ suite('Static get styles', () => {
             getComputedStyle(div).getPropertyValue('border-top-width').trim(),
             '4px');
 
+        // The CSSStyleSheet isn't flattened, so changes can take effect.
         sheet.replaceSync('div { border: 2px solid red; }');
         assert.equal(
             getComputedStyle(div).getPropertyValue('border-top-width').trim(),
             '2px');
       });
 
-  // Test that when ShadyCSS is enabled _even with_ native support, we can return
-  // a CSSStyleSheet that will be flattened and play nice with others.
-  const testShadyCSSWithAdoptedStyleSheetSupport = (window.ShadyCSS !== undefined) &&
-      (typeof ShadowRoot === 'function') &&
-      ('adoptedStyleSheets' in window.ShadowRoot.prototype);
+  // Test that when ShadyCSS is enabled with native support for
+  // adoptedStyleSheets, we can return a CSSStyleSheet that will be flattened
+  // and play nice with others.
+  const testShadyCSSWithAdoptedStyleSheetSupport = (typeof ShadowRoot === 'function') &&
+      ('adoptedStyleSheets' in window.ShadowRoot.prototype) &&
+      (window.ShadyCSS !== undefined && !window.ShadyCSS.nativeShadow);
   (testShadyCSSWithAdoptedStyleSheetSupport ? test : test.skip)(
       'CSSStyleSheet is flattened where ShadyCSS is enabled yet adoptedStyleSheets are supported',
       async () => {

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -968,7 +968,7 @@ suite('Static get styles', () => {
 
         const base = generateElementName();
         customElements.define(base, class extends LitElement {
-          static styles = [sheet, normal]
+          static styles = [sheet, normal];
 
           render() {
             return htmlWithStyles`<div></div><span></span>`;
@@ -979,19 +979,17 @@ suite('Static get styles', () => {
         container.appendChild(el);
         await (el as LitElement).updateComplete;
 
-        // CSSStyleSheet
         const div = el.shadowRoot!.querySelector('div')!;
         assert.equal(
             getComputedStyle(div).getPropertyValue('border-top-width').trim(),
             '4px');
 
-        // css-tag
         const span = el.shadowRoot!.querySelector('span')!;
         assert.equal(
             getComputedStyle(span).getPropertyValue('border-top-width').trim(),
             '4px');
 
-        // CSSStyleSheet update
+        // CSSStyleSheet update should fail, as the styles will be flattened.
         sheet.replaceSync('div { border: 2px solid red; }');
         assert.equal(
           getComputedStyle(div).getPropertyValue('border-top-width').trim(),

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -924,8 +924,9 @@ suite('Static get styles', () => {
       });
 
   // Test this in Shadow DOM without `adoptedStyleSheets` only since it's easily
-  // detectable in that case.
-  const testNativeAdoptedStyleSheets = (typeof ShadowRoot === 'function') &&
+  // detectable in that case. Look explicitly for no ShadyCSS.
+  const testNativeAdoptedStyleSheets = (window.ShadyCSS === undefined) &&
+      (typeof ShadowRoot === 'function') &&
       ('adoptedStyleSheets' in window.ShadowRoot.prototype);
   (testNativeAdoptedStyleSheets ? test : test.skip)(
       'Can return CSSStyleSheet where adoptedStyleSheets are natively supported',
@@ -959,7 +960,8 @@ suite('Static get styles', () => {
   // Test that when ShadyCSS is enabled _even with_ native support, we can return
   // a CSSStyleSheet that will be flattened and play nice with others.
   const testShadyCSSWithAdoptedStyleSheetSupport = (window.ShadyCSS !== undefined) &&
-        testNativeAdoptedStyleSheets;
+      (typeof ShadowRoot === 'function') &&
+      ('adoptedStyleSheets' in window.ShadowRoot.prototype);
   (testShadyCSSWithAdoptedStyleSheetSupport ? test : test.skip)(
       'CSSStyleSheet is flattened where ShadyCSS is enabled yet adoptedStyleSheets are supported',
       async () => {

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -902,7 +902,7 @@ suite('Static get styles', () => {
       'Non-adoptible stylesheet is flattened to a CSSResult',
       async () => {
         const s = document.createElement('style');
-        s.textContent = `@media (max-width: 768px) { #_adoptible_test { color: red; } }`;
+        s.textContent = `@media (max-width: 768px) { #_adoptible_test { border: 4px solid red; } }`;
         container.appendChild(s);
         const sheetFromStyle = s.sheet;
         container.removeChild(s);
@@ -921,8 +921,8 @@ suite('Static get styles', () => {
         await (el as LitElement).updateComplete;
         const div = el.shadowRoot!.querySelector('div')!;
         assert.equal(
-            getComputedStyle(div).getPropertyValue('color').trim(),
-            'red');
+            getComputedStyle(div).getPropertyValue('border-top-width').trim(),
+            '4px');
       });
 
   // Test this in Shadow DOM without `adoptedStyleSheets` only since it's easily

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -952,8 +952,8 @@ suite('Static get styles', () => {
 
         sheet.replaceSync('div { border: 2px solid red; }');
         assert.equal(
-          getComputedStyle(div).getPropertyValue('border-top-width').trim(),
-          '2px');
+            getComputedStyle(div).getPropertyValue('border-top-width').trim(),
+            '2px');
       });
 
   // Test that when ShadyCSS is enabled _even with_ native support, we can return
@@ -961,6 +961,7 @@ suite('Static get styles', () => {
   const testShadyCSSWithAdoptedStyleSheetSupport = (window.ShadyCSS !== undefined) &&
         testNativeAdoptedStyleSheets;
   (testShadyCSSWithAdoptedStyleSheetSupport ? test : test.skip)(
+      'CSSStyleSheet is flattened where ShadyCSS is enabled yet adoptedStyleSheets are supported',
       async () => {
         const sheet = new CSSStyleSheet();
         sheet.replaceSync('div { border: 4px solid red; }');
@@ -992,8 +993,8 @@ suite('Static get styles', () => {
         // CSSStyleSheet update should fail, as the styles will be flattened.
         sheet.replaceSync('div { border: 2px solid red; }');
         assert.equal(
-          getComputedStyle(div).getPropertyValue('border-top-width').trim(),
-          '4px', 'CSS should not reflect CSSStyleSheet as it was flattened');
+            getComputedStyle(div).getPropertyValue('border-top-width').trim(),
+            '4px', 'CSS should not reflect CSSStyleSheet as it was flattened');
       });
 });
 

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -828,8 +828,7 @@ suite('Static get styles', () => {
         'el2 styled correctly');
     assert.equal(
         stylesCounter, 1, 'styles property should only be accessed once');
-    assert.equal(
-      getStylesCounter, 1, 'getStyles() should be called once');
+    assert.equal(getStylesCounter, 1, 'getStyles() should be called once');
   });
 
   test(
@@ -901,8 +900,7 @@ suite('Static get styles', () => {
 
   // Test this in Shadow DOM without `adoptedStyleSheets` only since it's easily
   // detectable in that case.
-  const testNativeAdoptedStyleSheets =
-      (typeof ShadowRoot === 'function') &&
+  const testNativeAdoptedStyleSheets = (typeof ShadowRoot === 'function') &&
       ('adoptedStyleSheets' in window.ShadowRoot.prototype);
   (testNativeAdoptedStyleSheets ? test : test.skip)(
       'Can return CSSStyleSheet where adoptedStyleSheets are natively supported',
@@ -924,9 +922,7 @@ suite('Static get styles', () => {
         await (el as LitElement).updateComplete;
         const div = el.shadowRoot!.querySelector('div')!;
         assert.equal(
-            getComputedStyle(div)
-                .getPropertyValue('border-top-width')
-                .trim(),
+            getComputedStyle(div).getPropertyValue('border-top-width').trim(),
             '4px');
       });
 });

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -912,15 +912,10 @@ suite('Static get styles', () => {
           static styles = (sheetFromStyle as CSSStyleSheet);
         });
 
-        const el = document.createElement(base);
-        container.appendChild(el);
-
-        try {
-          await (el as LitElement).updateComplete;
-          assert.fail('update should fail as <style>.sheet is disallowed');
-        } catch (e) {
-          // ok
-        }
+        assert.throws(() => {
+          const el = document.createElement(base);
+          container.appendChild(el);
+        });
       });
 
   // Test this in Shadow DOM without `adoptedStyleSheets` only since it's easily


### PR DESCRIPTION
Fixes #774. Supports native `CSSStyleSheet` if and only if native adopted style sheets on shadow roots are supported.
