### PR TITLE
Move style gathering from class finalization to initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,7 @@ dist: xenial
 node_js: '10'
 addons:
   firefox: latest
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
 cache:
   directories:
   - node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 * Properties annotated with the `eventOptions` decorator will now survive property renaming optimizations when used with tsickle and Closure JS Compiler.
+* Moved style gathering from `finalize` to `initialize` to be more lazy, and create stylesheets on the first instance initializing.
 
 <!-- ### Changed -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Added `enableUpdating()` to `UpdatingElement` to enable customizing when updating is enabled [#860](https://github.com/Polymer/lit-element/pull/860).
 * Added `queryAssignedNodes(slotName, flatten)` to enable querying assignedNodes for a given slot [#860](https://github.com/Polymer/lit-element/pull/860).
+* Added `getStyles()` to `LitElement` to allow hooks into style gathering for component sets [#866](https://github.com/Polymer/lit-element/pull/866).
 
 ### Fixed
 * Properties annotated with the `eventOptions` decorator will now survive property renaming optimizations when used with tsickle and Closure JS Compiler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 * Properties annotated with the `eventOptions` decorator will now survive property renaming optimizations when used with tsickle and Closure JS Compiler.
-* Moved style gathering from `finalize` to `initialize` to be more lazy, and create stylesheets on the first instance initializing.
+* Moved style gathering from `finalize` to `initialize` to be more lazy, and create stylesheets on the first instance initializing [#866](https://github.com/Polymer/lit-element/pull/866).
 
 <!-- ### Changed -->
 

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -265,7 +265,8 @@ export function eventOptions(options: AddEventListenerOptions) {
  * this property should be annotated as `NodeListOf<HTMLElement>`.
  *
  */
-export function queryAssignedNodes(slotName: string = '', flatten: boolean = false) {
+export function queryAssignedNodes(
+    slotName: string = '', flatten: boolean = false) {
   return (protoOrDescriptor: Object|ClassElement,
           // tslint:disable-next-line:no-any decorator
           name?: PropertyKey): any => {

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -132,7 +132,8 @@ type AttributeMap = Map<string, PropertyKey>;
  * interface corresponding to the declared element properties.
  */
 // tslint:disable-next-line:no-any
-export type PropertyValues<T = any> = keyof T extends PropertyKey ? Map<keyof T, unknown> : never;
+export type PropertyValues<T = any> =
+    keyof T extends PropertyKey ? Map<keyof T, unknown>: never;
 
 export const defaultConverter: ComplexAttributeConverter = {
 

--- a/src/test/lib/decorators_test.ts
+++ b/src/test/lib/decorators_test.ts
@@ -16,7 +16,8 @@ import {eventOptions, property} from '../../lib/decorators.js';
 import {customElement, html, LitElement, PropertyValues, query, queryAll, queryAssignedNodes} from '../../lit-element.js';
 import {generateElementName} from '../test-helpers.js';
 
-const flush = window.ShadyDOM && window.ShadyDOM.flush ? window.ShadyDOM.flush : () => {};
+const flush =
+    window.ShadyDOM && window.ShadyDOM.flush ? window.ShadyDOM.flush : () => {};
 
 // tslint:disable:no-any ok in tests
 

--- a/src/test/lit-element_styling_test.ts
+++ b/src/test/lit-element_styling_test.ts
@@ -788,6 +788,40 @@ suite('Static get styles', () => {
         '4px');
   });
 
+  test('element class only gathers styles once', async () => {
+    const base = generateElementName();
+    let styleCounter = 0;
+    customElements.define(base, class extends LitElement {
+      static get styles() {
+        styleCounter++;
+        return css`:host {
+          border: 10px solid black;
+        }`;
+      }
+      render() {
+        return htmlWithStyles`<div>styled</div>`;
+      }
+    });
+    const el1 = document.createElement(base);
+    const el2 = document.createElement(base);
+    container.appendChild(el1);
+    container.appendChild(el2);
+    await Promise.all([
+      (el1 as LitElement).updateComplete,
+      (el2 as LitElement).updateComplete
+    ]);
+    assert.equal(
+        getComputedStyle(el1).getPropertyValue('border-top-width').trim(),
+        '10px',
+        'el1 styled correctly');
+    assert.equal(
+        getComputedStyle(el2).getPropertyValue('border-top-width').trim(),
+        '10px',
+        'el2 styled correctly');
+    assert.equal(
+        styleCounter, 1, 'styles property should only be accessed once');
+  });
+
   test(
       '`CSSResult` allows for String type coercion via toString()',
       async () => {


### PR DESCRIPTION
By moving style gathering to initialization, stylesheets will only be
created for elements that have booted, and not for elements that have
only be registered.

This should be performance positive for applications with less than
ideal loading behaviors.

Fixes #870 