### PR TITLE
fix Update fromAttribute complex type when value is not valid

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -112,6 +112,14 @@ export interface PropertyDeclaration<Type = unknown, TypeHint = unknown> {
    * the property changes.
    */
   readonly noAccessor?: boolean;
+
+  /**
+   * Indicates fallback value will be return when parsing in
+   * `fromAttribute` catch an exception.
+   * By default, fallback value is `undefined`
+   */
+  // tslint:disable-next-line:no-any
+  readonly onError?: any;
 }
 
 /**
@@ -157,18 +165,12 @@ export const defaultConverter: ComplexAttributeConverter = {
       case Number:
         return value === null ? null : Number(value);
       case Object:
-        try {
-          return JSON.parse(value!);
-        } catch (e) {
-          // Ignore any previous errors. Only return a empty object
-          return {};
-        }
       case Array:
         try {
           return JSON.parse(value!);
         } catch (e) {
-          // Ignore any previous errors. Only return a empty array
-          return [];
+          // Ignore any previous errors. Only return a empty object
+          return defaultPropertyDeclaration.onError;
         }
     }
     return value;
@@ -194,7 +196,8 @@ const defaultPropertyDeclaration: PropertyDeclaration = {
   type: String,
   converter: defaultConverter,
   reflect: false,
-  hasChanged: notEqual
+  hasChanged: notEqual,
+  onError: undefined
 };
 
 const STATE_HAS_UPDATED = 1;

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -157,8 +157,19 @@ export const defaultConverter: ComplexAttributeConverter = {
       case Number:
         return value === null ? null : Number(value);
       case Object:
+        try {
+          return JSON.parse(value!);
+        } catch (e) {
+          // Ignore any previous errors. Only return a empty object
+          return {};
+        }
       case Array:
-        return JSON.parse(value!);
+        try {
+          return JSON.parse(value!);
+        } catch (e) {
+          // Ignore any previous errors. Only return a empty array
+          return [];
+        }
     }
     return value;
   }

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -736,6 +736,29 @@ suite('UpdatingElement', () => {
     assert.deepEqual(el.arr, [1, 2, 3, 4]);
   });
 
+  test('array and object attributes deserialize from html when value is no valid ', async () => {
+    class E extends UpdatingElement {
+      static get properties() {
+        return {
+          obj: {type: Object},
+          arr: {type: Array}
+        };
+      }
+
+      obj?: any;
+      arr?: any;
+    }
+    const name = generateElementName();
+    customElements.define(name, E);
+    container.innerHTML = `<${name}
+      obj='{InvalidJsonFormat}'
+      arr='[a,b,c,d]'></${name}>`;
+    const el = container.firstChild as E;
+    await el.updateComplete;
+    assert.deepEqual(el.obj, {});
+    assert.deepEqual(el.arr, []);
+  });
+
   if ((Object as Partial<typeof Object>).getOwnPropertySymbols) {
     test('properties defined using symbols', async () => {
       const zug = Symbol();

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -755,8 +755,8 @@ suite('UpdatingElement', () => {
       arr='[a,b,c,d]'></${name}>`;
     const el = container.firstChild as E;
     await el.updateComplete;
-    assert.deepEqual(el.obj, {});
-    assert.deepEqual(el.arr, []);
+    assert.deepEqual(el.obj, undefined);
+    assert.deepEqual(el.arr, undefined);
   });
 
   if ((Object as Partial<typeof Object>).getOwnPropertySymbols) {


### PR DESCRIPTION
For better understanding on the issue please check #722

Following pull request #723. I added test and take in account return made.

This happens because JSON.parse('') will be fired when value is an invalid JSON. 

So now it's return an empty array or empty object.

**Reference Issue**

Fixes #722
