### PR TITLE
Makes `createProperty` easier to use to customize properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Changed
-* The static `createProperty` method has a new argument to allow easier customization of property accessors. A `descriptorFactory(options, descriptor, key)` can be optionally passed and should return a `PropertyDescriptor` to install on the property. If no descriptor is returned, a property accessors will not be created. ([#911](https://github.com/Polymer/lit-element/issues/911))
+* Added a static `createPropertyDescriptor` method to allow easier customization of property accessors. This method should return a a `PropertyDescriptor` to install on the property. If no descriptor is returned, a property accessor is not be created. ([#911](https://github.com/Polymer/lit-element/issues/911))
 * The value returned by `render` is always rendered, even if it isn't a `TemplateResult`. ([#712](https://github.com/Polymer/lit-element/issues/712))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Changed
-* Added a static `createPropertyDescriptor` method to allow easier customization of property accessors. This method should return a a `PropertyDescriptor` to install on the property. If no descriptor is returned, a property accessor is not be created. ([#911](https://github.com/Polymer/lit-element/issues/911))
+* Added a static `getPropertyDescriptor` method to allow easier customization of property accessors. This method should return a a `PropertyDescriptor` to install on the property. If no descriptor is returned, a property accessor is not be created. ([#911](https://github.com/Polymer/lit-element/issues/911))
 * The value returned by `render` is always rendered, even if it isn't a `TemplateResult`. ([#712](https://github.com/Polymer/lit-element/issues/712))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Changed
-* The value returned by `render` is always rendered, even if it isn't a `TemplateResult`. ([#712](https://github.com/Polymer/lit-element/issues/712)
+* The static `createProperty` method has a new argument to allow easier customization of property accessors. A `descriptorFactory(options, descriptor, key)` can be optionally passed and should return a `PropertyDescriptor` to install on the property. If no descriptor is returned, a property accessors will not be created. ([#911](https://github.com/Polymer/lit-element/issues/911))
+* The value returned by `render` is always rendered, even if it isn't a `TemplateResult`. ([#712](https://github.com/Polymer/lit-element/issues/712))
 
 ### Added
 * Added `@queryAsync(selector)` decorator which returns a Promise that resolves to the result of querying for the given selector after the element's `updateComplete` Promise resolves ([#903](https://github.com/Polymer/lit-element/issues/903)).

--- a/src/demo/ts-element.ts
+++ b/src/demo/ts-element.ts
@@ -4,7 +4,7 @@ class TSElement extends LitElement {
   @property() message = 'Hi';
 
   @property(
-      {attribute: 'more-info', converter: (value: string) => `[${value}]`})
+      {attribute: 'more-info', converter: (value: string|null) => `[${value}]`})
   extra = '';
 
   render() {

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -174,7 +174,7 @@ export interface HasChanged {
 }
 
 export type PropertyDescriptorFactory = (options: PropertyDeclaration,
-  descriptor: PropertyDescriptor, key: string|symbol) => PropertyDescriptor|null|void;
+  descriptor: PropertyDescriptor, key: string|symbol) => PropertyDescriptor|undefined;
 
 /**
  * Change function that returns true if `value` is different from `oldValue`.
@@ -312,7 +312,7 @@ export abstract class UpdatingElement extends HTMLElement {
       return;
     }
     const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
-    let descriptor: PropertyDescriptor|null|void = {
+    let descriptor: PropertyDescriptor|undefined = {
       // tslint:disable-next-line:no-any no symbol in index
       get(): any {
         return (this as {[key: string]: unknown})[key as string];
@@ -329,7 +329,7 @@ export abstract class UpdatingElement extends HTMLElement {
     if (typeof descriptorFactory === 'function') {
       descriptor = descriptorFactory(options, descriptor, key);
     }
-    if (descriptor != null) {
+    if (descriptor !== undefined) {
       Object.defineProperty(this.prototype, name, descriptor);
     }
   }

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -314,6 +314,29 @@ export abstract class UpdatingElement extends HTMLElement {
     }
   }
 
+  /**
+   * Creates a property descriptor to be defined on the given named property.
+   * If no descriptor is returned, the property will not become an accessor.
+   * For example,
+   *
+   *   class MyElement extends LitElement {
+   *     static createPropertyDescriptor(name, key, options) {
+   *       const defaultDescriptor = super.createPropertyDescriptor(name, key, options);
+   *       const setter = defaultDescriptor.set;
+   *       return {
+   *         get: defaultDescriptor.get,
+   *         set(value) {
+   *           setter.call(this, value);
+   *           // custom action.
+   *         },
+   *         configurable: true,
+   *         enumerable: true
+   *       }
+   *     }
+   *   }
+   *
+   * @nocollapse
+   */
   protected static createPropertyDescriptor(name: PropertyKey,
     key: string|symbol, _options: PropertyDeclaration,) {
     return {
@@ -698,6 +721,9 @@ export abstract class UpdatingElement extends HTMLElement {
    * ```
    */
   protected performUpdate(): void|Promise<unknown> {
+    if (!this._hasRequestedUpdate) {
+      return;
+    }
     // Mixin instance properties once, if they exist.
     if (this._instanceProperties) {
       this._applyInstanceProperties();

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -297,6 +297,7 @@ export abstract class UpdatingElement extends HTMLElement {
    * `createPropertyDescriptor` internally to get a descriptor to install.
    * To customize what properties do when they are get or set, override
    * `createPropertyDescriptor`. To customize the options for a property,
+   * implement `createProperty` like this:
    *
    * static createProperty(name, options) {
    *   options = Object.assign(options, {myOption: true});

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -174,7 +174,7 @@ export interface HasChanged {
 }
 
 export type PropertyDescriptorFactory = (options: PropertyDeclaration,
-  key: string|symbol,descriptor: PropertyDescriptor) => PropertyDescriptor|null|void;
+  descriptor: PropertyDescriptor, key: string|symbol) => PropertyDescriptor|null|void;
 
 /**
  * Change function that returns true if `value` is different from `oldValue`.
@@ -327,7 +327,7 @@ export abstract class UpdatingElement extends HTMLElement {
       enumerable: true
     };
     if (typeof descriptorFactory === 'function') {
-      descriptor = descriptorFactory(options, key, descriptor);
+      descriptor = descriptorFactory(options, descriptor, key);
     }
     if (descriptor != null) {
       Object.defineProperty(this.prototype, name, descriptor);

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -294,9 +294,9 @@ export abstract class UpdatingElement extends HTMLElement {
    * This method may be overridden to customize properties; however,
    * when doing so, it's important to call `super.createProperty` to ensure
    * the property is setup correctly. This method calls
-   * `createPropertyDescriptor` internally to get a descriptor to install.
+   * `getPropertyDescriptor` internally to get a descriptor to install.
    * To customize what properties do when they are get or set, override
-   * `createPropertyDescriptor`. To customize the options for a property,
+   * `getPropertyDescriptor`. To customize the options for a property,
    * implement `createProperty` like this:
    *
    * static createProperty(name, options) {
@@ -323,20 +323,20 @@ export abstract class UpdatingElement extends HTMLElement {
       return;
     }
     const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
-    const descriptor = this.createPropertyDescriptor(name, key, options);
+    const descriptor = this.getPropertyDescriptor(name, key, options);
     if (descriptor !== undefined) {
       Object.defineProperty(this.prototype, name, descriptor);
     }
   }
 
   /**
-   * Creates a property descriptor to be defined on the given named property.
+   * Returns a property descriptor to be defined on the given named property.
    * If no descriptor is returned, the property will not become an accessor.
    * For example,
    *
    *   class MyElement extends LitElement {
-   *     static createPropertyDescriptor(name, key, options) {
-   *       const defaultDescriptor = super.createPropertyDescriptor(name, key, options);
+   *     static getPropertyDescriptor(name, key, options) {
+   *       const defaultDescriptor = super.getPropertyDescriptor(name, key, options);
    *       const setter = defaultDescriptor.set;
    *       return {
    *         get: defaultDescriptor.get,
@@ -352,7 +352,7 @@ export abstract class UpdatingElement extends HTMLElement {
    *
    * @nocollapse
    */
-  protected static createPropertyDescriptor(name: PropertyKey,
+  protected static getPropertyDescriptor(name: PropertyKey,
     key: string|symbol, _options: PropertyDeclaration) {
     return {
       // tslint:disable-next-line:no-any no symbol in index
@@ -379,6 +379,7 @@ export abstract class UpdatingElement extends HTMLElement {
    * Note, this method should be considered "final" and not overridden. To
    * customize the options for a given property, override `createProperty`.
    *
+   * @final
    */
   protected static getPropertyOptions(name: PropertyKey) {
     return this._classProperties && this._classProperties.get(name) ||

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -285,10 +285,24 @@ export abstract class UpdatingElement extends HTMLElement {
   }
 
   /**
-   * Creates a property accessor on the element prototype if one does not exist.
+   * Creates a property accessor on the element prototype if one does not exist
+   * and stores a PropertyDeclaration for the property with the given options.
    * The property setter calls the property's `hasChanged` property option
    * or uses a strict identity check to determine whether or not to request
    * an update.
+   *
+   * This method may be overridden to customize properties; however,
+   * when doing so, it's important to call `super.createProperty` to ensure
+   * the property is setup correctly. This method calls
+   * `createPropertyDescriptor` internally to get a descriptor to install.
+   * To customize what properties do when they are get or set, override
+   * `createPropertyDescriptor`. To customize the options for a property,
+   *
+   * static createProperty(name, options) {
+   *   options = Object.assign(options, {myOption: true});
+   *   super.createProperty(name, options);
+   * }
+   *
    * @nocollapse
    */
   static createProperty(
@@ -338,7 +352,7 @@ export abstract class UpdatingElement extends HTMLElement {
    * @nocollapse
    */
   protected static createPropertyDescriptor(name: PropertyKey,
-    key: string|symbol, _options: PropertyDeclaration,) {
+    key: string|symbol, _options: PropertyDeclaration) {
     return {
       // tslint:disable-next-line:no-any no symbol in index
       get(): any {
@@ -355,7 +369,17 @@ export abstract class UpdatingElement extends HTMLElement {
     };
   }
 
-  protected static getDeclarationForProperty(name: PropertyKey) {
+  /**
+   * Returns the property options associated with the given property.
+   * These options are defined with a PropertyDeclaration via the `properties`
+   * object or the `@property` decorator and are registered in
+   * `createProperty(...)`.
+   *
+   * Note, this method should be considered "final" and not overridden. To
+   * customize the options for a given property, override `createProperty`.
+   *
+   */
+  protected static getPropertyOptions(name: PropertyKey) {
     return this._classProperties && this._classProperties.get(name) ||
       defaultPropertyDeclaration;
   }
@@ -432,10 +456,9 @@ export abstract class UpdatingElement extends HTMLElement {
   private static _propertyValueFromAttribute(
       value: string|null, options: PropertyDeclaration) {
     const type = options.type;
-    const converter = options.converter ||
-      defaultPropertyDeclaration.converter;
+  const converter = options.converter || defaultConverter;
     const fromAttribute =
-        (typeof converter === 'function' ? converter : converter!.fromAttribute);
+      (typeof converter === 'function' ? converter : converter.fromAttribute);
     return fromAttribute ? fromAttribute(value, type) : value;
   }
 
@@ -453,14 +476,11 @@ export abstract class UpdatingElement extends HTMLElement {
       return;
     }
     const type = options.type;
-    let converter = options.converter;
-    let toAttribute =
-        converter && (converter as ComplexAttributeConverter).toAttribute;
-    if (!toAttribute) {
-      converter = defaultPropertyDeclaration.converter;
-      toAttribute = converter && (converter as ComplexAttributeConverter).toAttribute;
-    }
-    return toAttribute ? toAttribute(value, type) : value;
+  const converter = options.converter;
+  const toAttribute =
+      converter && (converter as ComplexAttributeConverter).toAttribute ||
+      defaultConverter.toAttribute;
+  return toAttribute!(value, type);
   }
 
   private _updateState: UpdateState = 0;
@@ -607,7 +627,7 @@ export abstract class UpdatingElement extends HTMLElement {
     const ctor = (this.constructor as typeof UpdatingElement);
     const propName = ctor._attributeToPropertyMap.get(name);
     if (propName !== undefined) {
-      const options = ctor.getDeclarationForProperty(propName);
+      const options = ctor.getPropertyOptions(propName);
       // mark state reflecting
       this._updateState = this._updateState | STATE_IS_REFLECTING_TO_PROPERTY;
       this[propName as keyof this] =
@@ -628,7 +648,7 @@ export abstract class UpdatingElement extends HTMLElement {
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
       const ctor = this.constructor as typeof UpdatingElement;
-      const options = ctor.getDeclarationForProperty(name);
+      const options = ctor.getPropertyOptions(name);
       if (ctor._valueHasChanged(
               this[name as keyof this], oldValue, options.hasChanged)) {
         if (!this._changedProperties.has(name)) {
@@ -721,9 +741,6 @@ export abstract class UpdatingElement extends HTMLElement {
    * ```
    */
   protected performUpdate(): void|Promise<unknown> {
-    if (!this._hasRequestedUpdate) {
-      return;
-    }
     // Mixin instance properties once, if they exist.
     if (this._instanceProperties) {
       this._applyInstanceProperties();

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -456,9 +456,9 @@ export abstract class UpdatingElement extends HTMLElement {
   private static _propertyValueFromAttribute(
       value: string|null, options: PropertyDeclaration) {
     const type = options.type;
-  const converter = options.converter || defaultConverter;
+    const converter = options.converter || defaultConverter;
     const fromAttribute =
-      (typeof converter === 'function' ? converter : converter.fromAttribute);
+        (typeof converter === 'function' ? converter : converter.fromAttribute);
     return fromAttribute ? fromAttribute(value, type) : value;
   }
 
@@ -476,11 +476,11 @@ export abstract class UpdatingElement extends HTMLElement {
       return;
     }
     const type = options.type;
-  const converter = options.converter;
-  const toAttribute =
-      converter && (converter as ComplexAttributeConverter).toAttribute ||
-      defaultConverter.toAttribute;
-  return toAttribute!(value, type);
+    const converter = options.converter;
+    const toAttribute =
+        converter && (converter as ComplexAttributeConverter).toAttribute ||
+        defaultConverter.toAttribute;
+    return toAttribute!(value, type);
   }
 
   private _updateState: UpdateState = 0;

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -325,7 +325,7 @@ export abstract class UpdatingElement extends HTMLElement {
         const oldValue =
             (this as {} as {[key: string]: unknown})[name as string];
         (this as {} as {[key: string]: unknown})[key as string] = value;
-        (this as unknown as UpdatingElement).requestUpdateInternal(name, oldValue);
+        (this as unknown as UpdatingElement)._requestUpdate(name, oldValue);
       },
       configurable: true,
       enumerable: true
@@ -473,7 +473,7 @@ export abstract class UpdatingElement extends HTMLElement {
     this._saveInstanceProperties();
     // ensures first update will be caught by an early access of
     // `updateComplete`
-    this.requestUpdateInternal();
+    this._requestUpdate();
   }
 
   /**
@@ -596,11 +596,11 @@ export abstract class UpdatingElement extends HTMLElement {
   }
 
   /**
-   * This protected version of `requestUpdate` does not access or return the
+   * This private version of `requestUpdate` does not access or return the
    * `updateComplete` promise. This promise can be overridden and is therefore
    * not free to access.
    */
-  protected requestUpdateInternal(name?: PropertyKey, oldValue?: unknown) {
+  private _requestUpdate(name?: PropertyKey, oldValue?: unknown) {
     let shouldRequestUpdate = true;
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
@@ -646,7 +646,7 @@ export abstract class UpdatingElement extends HTMLElement {
    * @returns {Promise} A Promise that is resolved when the update completes.
    */
   requestUpdate(name?: PropertyKey, oldValue?: unknown) {
-    this.requestUpdateInternal(name, oldValue);
+    this._requestUpdate(name, oldValue);
     return this.updateComplete;
   }
 

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1871,8 +1871,8 @@ suite('UpdatingElement', () => {
     @customElement(generateElementName())
     class E extends UpdatingElement {
 
-      static createPropertyDescriptor(name: PropertyKey, key: string|symbol, options: MyPropertyDeclaration) {
-        const defaultDescriptor = super.createPropertyDescriptor(name, key, options);
+      static getPropertyDescriptor(name: PropertyKey, key: string|symbol, options: MyPropertyDeclaration) {
+        const defaultDescriptor = super.getPropertyDescriptor(name, key, options);
         return {
           get: defaultDescriptor.get,
           set(this: E, value: unknown) {

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1844,7 +1844,7 @@ suite('UpdatingElement', () => {
           foo = 5;
 
           @property({type: String})
-          bar? = 'bar';
+          bar?: string = 'bar';
         }
 
         const el = new E();

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1874,7 +1874,7 @@ suite('UpdatingElement', () => {
         name: PropertyKey,
         options: MyPropertyDeclaration) {
           const descriptorFactory = (options: MyPropertyDeclaration,
-            _key: string|symbol, descriptor: PropertyDescriptor) => ({
+            descriptor: PropertyDescriptor) => ({
             // tslint:disable-next-line:no-any no symbol in index
             get: descriptor.get,
             set(this: E, value: unknown) {

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1874,7 +1874,7 @@ suite('UpdatingElement', () => {
       static createPropertyDescriptor(name: PropertyKey, key: string|symbol, options: MyPropertyDeclaration) {
         const defaultDescriptor = super.createPropertyDescriptor(name, key, options);
         return {
-          get: defaultDescriptor!.get,
+          get: defaultDescriptor.get,
           set(this: E, value: unknown) {
             const oldValue =
               (this as unknown as {[key: string]: unknown})[name as string];
@@ -1894,7 +1894,7 @@ suite('UpdatingElement', () => {
         super.updated(changedProperties);
         changedProperties.forEach((value: unknown, key: PropertyKey) => {
           const options = (this.constructor as typeof UpdatingElement)
-            .getDeclarationForProperty(key) as MyPropertyDeclaration;
+            .getPropertyOptions(key) as MyPropertyDeclaration;
           const observer = options.observer;
           if (typeof observer === 'function') {
             observer.call(this, value);

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1,4 +1,4 @@
- /**
+/**
  * @license
  * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -1874,14 +1874,17 @@ suite('UpdatingElement', () => {
       static createPropertyDescriptor(name: PropertyKey, key: string|symbol, options: MyPropertyDeclaration) {
         const defaultDescriptor = super.createPropertyDescriptor(name, key, options);
         return {
-          // tslint:disable-next-line:no-any no symbol in index
           get: defaultDescriptor!.get,
           set(this: E, value: unknown) {
+            const oldValue =
+              (this as unknown as {[key: string]: unknown})[name as string];
             if (options.validator) {
               value = options.validator(value);
             }
-            defaultDescriptor.set?.call(this, value);
+            (this as unknown as {[key: string]: unknown})[key as string] = value;
+            (this as unknown as UpdatingElement).requestUpdate(name, oldValue);
           },
+
           configurable: defaultDescriptor.configurable,
           enumerable: defaultDescriptor.enumerable
         };

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {property} from '../../lib/decorators.js';
-import {ComplexAttributeConverter, PropertyDeclarations, PropertyValues, UpdatingElement} from '../../lib/updating-element.js';
+import {property, customElement} from '../../lib/decorators.js';
+import {ComplexAttributeConverter, PropertyDeclarations, PropertyValues, UpdatingElement, PropertyDeclaration} from '../../lib/updating-element.js';
 import {generateElementName} from '../test-helpers.js';
 
 // tslint:disable:no-any ok in tests
@@ -1801,6 +1801,58 @@ suite('UpdatingElement', () => {
         assert.equal(sub.updatedText, '5');
         assert.equal(sub.getAttribute('foo'), '5');
       });
+
+  test.only('can implement createProperty to customize property options and accessors', async () => {
+
+    interface MyPropertyDeclaration<TypeHint = unknown> extends PropertyDeclaration {
+      validator?: (value: any) => TypeHint;
+    }
+
+    @customElement(generateElementName())
+    class E extends UpdatingElement {
+
+      static createProperty(
+        name: PropertyKey,
+        options: MyPropertyDeclaration) {
+        this.setOptionsForProperty(name, options);
+        if (options.noAccessor || this.prototype.hasOwnProperty(name)) {
+          return;
+        }
+        const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
+        Object.defineProperty(this.prototype, name, {
+          // tslint:disable-next-line:no-any no symbol in index
+          get(): any {
+            return (this as {[key: string]: unknown})[key as string];
+          },
+          set(this: E, value: unknown) {
+            const oldValue =
+                (this as {} as {[key: string]: unknown})[name as string];
+            if (options.validator) {
+              value = options.validator(value);
+            }
+            (this as {} as {[key: string]: unknown})[key as string] = value;
+            (this as unknown as E).requestUpdateInternal(name, oldValue);
+          },
+          configurable: true,
+          enumerable: true
+        });
+      }
+
+      @property({type: Number, validator: (value: number) => Math.min(10, Math.max(value, 0))})
+      foo = 5;
+
+      @property({})
+      bar = 'bar';
+    }
+
+    const el = new E();
+    container.appendChild(el);
+    await el.updateComplete;
+    el.foo = 20;
+    assert.equal(el.foo, 10);
+    el.foo = -5;
+    assert.equal(el.foo, 0);
+  });
 
   test('attribute-based property storage', async () => {
     class E extends UpdatingElement {


### PR DESCRIPTION
Fixes #911. It is now easier to override property accessor creation. A new static `getPropertyDescriptor(name: PropertyKey, key: string|symbol, options: PropertyDeclaraction)` is added here. This method should return a [property descriptor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) to use when defining the property. If no descriptor is returned, the property will not become an accessor.

Example:

```
class MyElement extends LitElement {
  static getPropertyDescriptor(
      name: PropertyKey,
      key: string|symbol,
      options: PropertyDeclaration) {

    const defaultDescriptor = super.getPropertyDescriptor(name, key, options); 
    const setter = defaultDescriptor.set;
    return Object.assign(descriptor, {
      set(this: MyElement, value: unknown) {
        setter.call(this, value);
        console.log('Property', name, 'was set to', value);
     }
  }
  //...
}
```
