### PR TITLE
Only call lit-html render if LitElement subclass implements render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 `LitElement` renders when updates are triggered as a result of rendering ([#549](https://github.com/Polymer/lit-element/issues/549)).
 * Properties annotated with the `eventOptions` decorator will now survive property renaming optimizations when used with tsickle and Closure JS Compiler.
 * Moved style gathering from `finalize` to `initialize` to be more lazy, and create stylesheets on the first instance initializing [#866](https://github.com/Polymer/lit-element/pull/866).
+* Fixed behavior change for components that do not implement `render()` introduced in ([#712](https://github.com/Polymer/lit-element/pull/712)) ([#917](https://github.com/Polymer/lit-element/pull/917))
 
 ## [2.2.1] - 2019-07-23
 ### Changed

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -35,6 +35,12 @@ declare global {
 
 export interface CSSResultArray extends Array<CSSResult|CSSResultArray> {}
 
+/**
+ * Sentinal value used to avoid calling lit-html's render function when
+ * subclasses do not implement `render`
+ */
+const renderNotImplemented = {};
+
 export class LitElement extends UpdatingElement {
   /**
    * Ensure this class is marked as `finalized` as an optimization ensuring
@@ -204,11 +210,14 @@ export class LitElement extends UpdatingElement {
     // before that.
     const templateResult = this.render();
     super.update(changedProperties);
-    (this.constructor as typeof LitElement)
-        .render(
-            templateResult,
-            this.renderRoot,
-            {scopeName: this.localName, eventContext: this});
+    // If render is not implemented by the component, don't call lit-html render
+    if (templateResult !== renderNotImplemented) {
+      (this.constructor as typeof LitElement)
+          .render(
+              templateResult,
+              this.renderRoot,
+              {scopeName: this.localName, eventContext: this});
+    }
     // When native Shadow DOM is used but adoptedStyles are not supported,
     // insert styling after rendering to ensure adoptedStyles have highest
     // priority.
@@ -229,6 +238,6 @@ export class LitElement extends UpdatingElement {
    * update.
    */
   protected render(): unknown {
-    return undefined;
+    return renderNotImplemented;
   }
 }

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -277,10 +277,6 @@ suite('LitElement', () => {
           createRenderRoot() {
             return this;
           }
-          connectedCallback() {
-            super.connectedCallback();
-            this.addedDom = this.renderRoot.querySelector('div');
-          }
         }
         customElements.define(generateElementName(), A);
         const a = new A();
@@ -288,10 +284,6 @@ suite('LitElement', () => {
         a.appendChild(testDom);
         container.appendChild(a);
         await a.updateComplete;
-        assert.equal(
-            a.addedDom,
-            testDom,
-            'testDom should be found in connectedCallback');
         assert.equal(
             testDom.parentNode,
             a,

--- a/src/test/lit-element_test.ts
+++ b/src/test/lit-element_test.ts
@@ -195,39 +195,42 @@ suite('LitElement', () => {
     assert.equal(window['litElementVersions'].length, 1);
   });
 
-  test('event fired during rendering element can trigger an update', async () => {
-    class E extends LitElement {
-      connectedCallback() {
-        super.connectedCallback();
-        this.dispatchEvent(new CustomEvent('foo', {bubbles: true, detail: 'foo'}));
-      }
-    }
-    customElements.define('x-child-61012', E);
+  test(
+      'event fired during rendering element can trigger an update',
+      async () => {
+        class E extends LitElement {
+          connectedCallback() {
+            super.connectedCallback();
+            this.dispatchEvent(
+                new CustomEvent('foo', {bubbles: true, detail: 'foo'}));
+          }
+        }
+        customElements.define('x-child-61012', E);
 
-    class F extends LitElement {
+        class F extends LitElement {
+          static get properties() {
+            return {foo: {type: String}};
+          }
 
-      static get properties() {
-        return {foo: {type: String}};
-      }
+          foo = '';
 
-      foo = '';
+          render() {
+            return html`<x-child-61012 @foo=${
+                this._handleFoo}></x-child-61012><span>${this.foo}</span>`;
+          }
 
-      render() {
-        return html`<x-child-61012 @foo=${this._handleFoo}></x-child-61012><span>${this.foo}</span>`;
-      }
+          _handleFoo(e: CustomEvent) {
+            this.foo = e.detail;
+          }
+        }
 
-      _handleFoo(e: CustomEvent) {
-        this.foo = e.detail;
-      }
-
-    }
-
-    customElements.define(generateElementName(), F);
-    const el = new F();
-    container.appendChild(el);
-    while (!(await el.updateComplete)) {}
-    assert.equal(el.shadowRoot!.textContent, 'foo');
-  });
+        customElements.define(generateElementName(), F);
+        const el = new F();
+        container.appendChild(el);
+        while (!(await el.updateComplete)) {
+        }
+        assert.equal(el.shadowRoot!.textContent, 'foo');
+      });
 
   test(
       'exceptions in `render` throw but do not prevent further updates',
@@ -265,5 +268,33 @@ suite('LitElement', () => {
         await a.updateComplete;
         assert.equal(a.foo, 20);
         assert.equal(a.shadowRoot!.textContent, '20');
+      });
+
+  test(
+      'if `render` is unimplemented, do not overwrite renderRoot', async () => {
+        class A extends LitElement {
+          addedDom: HTMLElement|null = null;
+          createRenderRoot() {
+            return this;
+          }
+          connectedCallback() {
+            super.connectedCallback();
+            this.addedDom = this.renderRoot.querySelector('div');
+          }
+        }
+        customElements.define(generateElementName(), A);
+        const a = new A();
+        const testDom = document.createElement('div');
+        a.appendChild(testDom);
+        container.appendChild(a);
+        await a.updateComplete;
+        assert.equal(
+            a.addedDom,
+            testDom,
+            'testDom should be found in connectedCallback');
+        assert.equal(
+            testDom.parentNode,
+            a,
+            'testDom should be a child of the component');
       });
 });


### PR DESCRIPTION
- #712 Introduced a breaking behavior change for situations where
  `render` is unimplemented, and DOM is added before being connected to
  the document.
