### PR TITLE
Fix static property for closure

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -379,6 +379,7 @@ export abstract class UpdatingElement extends HTMLElement {
    * Note, this method should be considered "final" and not overridden. To
    * customize the options for a given property, override `createProperty`.
    *
+   * @nocollapse
    * @final
    */
   protected static getPropertyOptions(name: PropertyKey) {


### PR DESCRIPTION
Static properties must use `@nocollapse`.