### PR TITLE
[docs] call template functions in composition examples

### DIFF
--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -366,9 +366,9 @@ You can compose LitElement templates from other LitElement templates. In the fol
 class MyPage extends LitElement {
   render() {
     return html`
-      ${this.headerTemplate}
-      ${this.articleTemplate}
-      ${this.footerTemplate}
+      ${this.headerTemplate()}
+      ${this.articleTemplate()}
+      ${this.footerTemplate()}
     `;
   }
   get headerTemplate() {
@@ -493,7 +493,7 @@ html`<button @click="${this.doStuff}"></button>`;
 
 render() {
   return html`
-    ${this.headerTemplate}
+    ${this.headerTemplate()}
     <article>article</article>
   `;
 }


### PR DESCRIPTION
Passing just the reference to the function doesn't seem to work, also lit-html docs don't state support for it: https://lit-html.polymer-project.org/guide/template-reference#supported-data-types-for-text-bindings

> Text content bindings accept a large range of value types:
>  * Primitive values.
>  * TemplateResult objects.
>  * DOM nodes.
>  * Arrays or iterables.

Calling the function results in passing TemplateResult which seems to work fine.