### PR TITLE
Micro-opt property sets and refactor initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 
 ### Added
+* The `requestUpdateInternal(name, oldValue, options)` method has been added. This method is sometimes useful to call in a custom property setter to optimize performance. It is slightly more efficient than `requestUpdate` since it does not return the `updateComplete` property which can be overridden to do work.
+
 * The protected `performUpdate()` method may now be called to syncronously "flush" a pending update, for example via a property setter. Note, performing a synchronous update only updates the element and not any potentially pending descendants in the element's local DOM ([#959](https://github.com/Polymer/lit-element/issues/959)).
 
 * Constructible stylesheets may now be provided directly as styles, in addition to using the `css` tagged template function ([#853](https://github.com/Polymer/lit-element/issues/853)).

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -357,7 +357,7 @@ export abstract class UpdatingElement extends HTMLElement {
    * @nocollapse
    */
   protected static getPropertyDescriptor(
-      name: PropertyKey, key: string|symbol, _options: PropertyDeclaration) {
+      name: PropertyKey, key: string|symbol, options: PropertyDeclaration) {
     return {
       // tslint:disable-next-line:no-any no symbol in index
       get(): any {
@@ -367,7 +367,7 @@ export abstract class UpdatingElement extends HTMLElement {
         const oldValue =
             (this as {} as {[key: string]: unknown})[name as string];
         (this as {} as {[key: string]: unknown})[key as string] = value;
-        (this as unknown as UpdatingElement)._requestUpdate(name, oldValue);
+        (this as unknown as UpdatingElement)._requestUpdate(name, oldValue, options);
       },
       configurable: true,
       enumerable: true
@@ -490,25 +490,23 @@ export abstract class UpdatingElement extends HTMLElement {
     return toAttribute!(value, type);
   }
 
-  private _updateState: UpdateState = 0;
-  private _instanceProperties: PropertyValues|undefined = undefined;
+  private _updateState!: UpdateState;
+  private _instanceProperties?: PropertyValues;
   // Initialize to an unresolved Promise so we can make sure the element has
   // connected before first update.
-  private _updatePromise =
-      new Promise((res) => this._enableUpdatingResolver = res);
+  private _updatePromise!: Promise<unknown>;
   private _enableUpdatingResolver: (() => void)|undefined;
 
   /**
    * Map with keys for any properties that have changed since the last
    * update cycle with previous values.
    */
-  private _changedProperties: PropertyValues = new Map();
+  private _changedProperties!: PropertyValues;
 
   /**
    * Map with keys of properties that should be reflected when updated.
    */
-  private _reflectingProperties: Map<PropertyKey, PropertyDeclaration>|
-      undefined = undefined;
+  private _reflectingProperties?: Map<PropertyKey, PropertyDeclaration>;
 
   constructor() {
     super();
@@ -520,6 +518,9 @@ export abstract class UpdatingElement extends HTMLElement {
    * registered properties.
    */
   protected initialize() {
+    this._updateState = 0;
+    this._updatePromise = new Promise((res) => this._enableUpdatingResolver = res);
+    this._changedProperties = new Map();
     this._saveInstanceProperties();
     // ensures first update will be caught by an early access of
     // `updateComplete`
@@ -653,12 +654,12 @@ export abstract class UpdatingElement extends HTMLElement {
    * `updateComplete` promise. This promise can be overridden and is therefore
    * not free to access.
    */
-  private _requestUpdate(name?: PropertyKey, oldValue?: unknown) {
+  private _requestUpdate(name?: PropertyKey, oldValue?: unknown, options?: PropertyDeclaration) {
     let shouldRequestUpdate = true;
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
       const ctor = this.constructor as typeof UpdatingElement;
-      const options = ctor.getPropertyOptions(name);
+      options = options || ctor.getPropertyOptions(name);
       if (ctor._valueHasChanged(
               this[name as keyof this], oldValue, options.hasChanged)) {
         if (!this._changedProperties.has(name)) {
@@ -698,8 +699,8 @@ export abstract class UpdatingElement extends HTMLElement {
    * @param oldValue {any} (optional) old value of requesting property
    * @returns {Promise} A Promise that is resolved when the update completes.
    */
-  requestUpdate(name?: PropertyKey, oldValue?: unknown) {
-    this._requestUpdate(name, oldValue);
+  requestUpdate(name?: PropertyKey, oldValue?: unknown, options?: PropertyDeclaration) {
+    this._requestUpdate(name, oldValue, options);
     return this.updateComplete;
   }
 

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -367,7 +367,7 @@ export abstract class UpdatingElement extends HTMLElement {
         const oldValue =
             (this as {} as {[key: string]: unknown})[name as string];
         (this as {} as {[key: string]: unknown})[key as string] = value;
-        (this as unknown as UpdatingElement)._requestUpdate(name, oldValue, options);
+        (this as unknown as UpdatingElement).requestUpdateInternal(name, oldValue, options);
       },
       configurable: true,
       enumerable: true
@@ -524,7 +524,7 @@ export abstract class UpdatingElement extends HTMLElement {
     this._saveInstanceProperties();
     // ensures first update will be caught by an early access of
     // `updateComplete`
-    this._requestUpdate();
+    this.requestUpdateInternal();
   }
 
   /**
@@ -650,11 +650,11 @@ export abstract class UpdatingElement extends HTMLElement {
   }
 
   /**
-   * This private version of `requestUpdate` does not access or return the
+   * This protected version of `requestUpdate` does not access or return the
    * `updateComplete` promise. This promise can be overridden and is therefore
    * not free to access.
    */
-  private _requestUpdate(name?: PropertyKey, oldValue?: unknown, options?: PropertyDeclaration) {
+  protected requestUpdateInternal(name?: PropertyKey, oldValue?: unknown, options?: PropertyDeclaration) {
     let shouldRequestUpdate = true;
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
@@ -699,8 +699,8 @@ export abstract class UpdatingElement extends HTMLElement {
    * @param oldValue {any} (optional) old value of requesting property
    * @returns {Promise} A Promise that is resolved when the update completes.
    */
-  requestUpdate(name?: PropertyKey, oldValue?: unknown, options?: PropertyDeclaration) {
-    this._requestUpdate(name, oldValue, options);
+  requestUpdate(name?: PropertyKey, oldValue?: unknown) {
+    this.requestUpdateInternal(name, oldValue);
     return this.updateComplete;
   }
 


### PR DESCRIPTION
* pass property options in default setter to avoid the map lookup
* move property initialization from constructor to initialize to provide additional control over construction