### PR TITLE
Fixes #965 as long as requestUpdate is called before setting other properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+### Fixed
+* Within a custom property setter, it is now possible to set another property that reflects to an attribute as long as it is done after calling `requestUpdate` ([#965](https://github.com/Polymer/lit-element/issues/965)).
+
 ### Added
 * The protected `performUpdate()` method may now be called to syncronously "flush" a pending update, for example via a property setter. Note, performing a synchronous update only updates the element and not any potentially pending descendants in the element's local DOM ([#959](https://github.com/Polymer/lit-element/issues/959)).
 

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -657,6 +657,8 @@ export abstract class UpdatingElement extends HTMLElement {
     let shouldRequestUpdate = true;
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
+      const isReflectingToProperty = this._updateState & STATE_IS_REFLECTING_TO_PROPERTY;
+      this._updateState = this._updateState & ~STATE_IS_REFLECTING_TO_PROPERTY;
       const ctor = this.constructor as typeof UpdatingElement;
       const options = ctor.getPropertyOptions(name);
       if (ctor._valueHasChanged(
@@ -668,8 +670,7 @@ export abstract class UpdatingElement extends HTMLElement {
         // Note, it's important that every change has a chance to add the
         // property to `_reflectingProperties`. This ensures setting
         // attribute + property reflects correctly.
-        if (options.reflect === true &&
-            !(this._updateState & STATE_IS_REFLECTING_TO_PROPERTY)) {
+        if (options.reflect === true && !isReflectingToProperty) {
           if (this._reflectingProperties === undefined) {
             this._reflectingProperties = new Map();
           }

--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -657,6 +657,9 @@ export abstract class UpdatingElement extends HTMLElement {
     let shouldRequestUpdate = true;
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
+      // Get the "reflecting to property" state and immediately reset it to
+      // false. This allows setting computed reflecting properties in custom
+      // setters after calling `requestUpdate`.
       const isReflectingToProperty = this._updateState & STATE_IS_REFLECTING_TO_PROPERTY;
       this._updateState = this._updateState & ~STATE_IS_REFLECTING_TO_PROPERTY;
       const ctor = this.constructor as typeof UpdatingElement;

--- a/src/test/lib/updating-element_test.ts
+++ b/src/test/lib/updating-element_test.ts
@@ -466,17 +466,23 @@ suite('UpdatingElement', () => {
       static get properties() {
         return {
           a: {type: Boolean},
-          b: {type: Number, reflect: true}
+          b: {type: Number, reflect: true},
+          c: {type: String},
+          d: {type: Number, reflect: true}
         };
       }
 
       _a: boolean;
       b: number;
+      _c: string;
+      d: number;
 
       constructor() {
         super();
         this._a = false;
         this.b = 0;
+        this._c = '';
+        this.d = 0;
       }
 
       get a() {
@@ -488,6 +494,19 @@ suite('UpdatingElement', () => {
         this._a = value;
         this.requestUpdate('a', oldValue);
         this.b += 1;
+        // checks that state is ok for additional attribute sets
+        this.setAttribute('c', this.c + 'c');
+      }
+
+      get c() {
+        return this._c;
+      }
+
+      set c(value: string) {
+        const oldValue = this.c;
+        this._c = value;
+        this.requestUpdate('c', oldValue);
+        this.d += 1;
       }
     }
     const name = generateElementName();
@@ -496,17 +515,26 @@ suite('UpdatingElement', () => {
     container.appendChild(el);
     await el.updateComplete;
     assert.equal(el.getAttribute('b'), '0');
+    assert.equal(el.getAttribute('d'), '0');
     el.a = true;
     await el.updateComplete;
     assert.equal(el.getAttribute('b'), '1');
+    assert.equal(el.getAttribute('d'), '1');
     el.a = false;
     el.a = true;
     el.a = false;
     await el.updateComplete;
     assert.equal(el.getAttribute('b'), '4');
+    assert.equal(el.getAttribute('d'), '4');
     el.setAttribute('a', '');
     await el.updateComplete;
     assert.equal(el.getAttribute('b'), '5');
+    assert.equal(el.getAttribute('d'), '5');
+    el.removeAttribute('a');
+    el.setAttribute('c', '');
+    await el.updateComplete;
+    assert.equal(el.getAttribute('b'), '6');
+    assert.equal(el.getAttribute('d'), '7');
   });
 
   test('property options via decorator', async () => {


### PR DESCRIPTION
It is now possible to set a computed reflecting property in another property's setter as long as `requestUpdate` is called before setting the computed property. Previous to this change, the following construction would fail:

```
// snippit from element class
@property({type: String, reflect: true}) b: string;

@property()
set a(value) {
  const oldValue = this.a;
  this._a = value;
  this.b = 'b';
  this.requestUpdate('a', oldValue);
}

// user code
el.setAttribute('a', 'a');
await el.updateComplete;
console.assert(el.getAttribute('b') == 'b') // false =(
```

With this change, the above code will still fail but it can be trivially changed so that it works by ensuring the other property is set after calling `requestUpdate`.

```
// updated snippit from class with everything the same except 
// where requestUpdate is called in the setter
set a(value) {
  const oldValue = this.a;
  this._a = value; 
  this.requestUpdate('a', oldValue); // ok to set a reflecting property after this
  this.b = 'b';
}

// user code
el.setAttribute('a', 'a');
await el.updateComplete;
console.assert(el.getAttribute('b') == 'b') // true =)

