### PR TITLE
remove link to PWA Starter Kit

### DIFF
--- a/docs/_guide/index.md
+++ b/docs/_guide/index.md
@@ -14,8 +14,6 @@ LitElement is a simple base class for creating fast, lightweight web components 
 
 LitElement uses [lit-html](https://lit-html.polymer-project.org/) to render into shadow DOM, and adds API to manage properties and attributes. Properties are observed by default, and elements update asynchronously when their properties change.
 
-To build an app out of LitElement components, check out [PWA Starter Kit](https://pwa-starter-kit.polymer-project.org/).
-
 ## Next steps
 
 * [Getting Started](/guide/start): Set up LitElement and create a component.


### PR DESCRIPTION
"PWA Starter Kit" is no longer under development, therefore I suggest to not link to it.

"lit-element-starter-ts" and "lit-element-starter-js" appear to be the new recommended starter projects. However, they are alredy linked on the getting started page.

Fixes #988