### PR TITLE
Consider npm ci rather than npm i in starter guide

### DIFF
--- a/docs/_guide/start.md
+++ b/docs/_guide/start.md
@@ -55,7 +55,7 @@ The quickest way to try out a project locally is to download one of the starter 
 
     ```bash
     cd <project folder>
-    npm i
+    npm ci
     ```
 
 <div class="alert alert-info">


### PR DESCRIPTION
Compared to npm i, npm ci:

* is faster
* installs a version of dependencies that have been tested to work together (by whoever last updated package-lock.json)

Downsides:

* Does not get the latest version of deps, so may miss new features and bug fixes

IMO it's better to give people who're just getting started a known good state.
