### PR TITLE
Add decorators to events, templates chapters.

### DIFF
--- a/docs/_guide/events.md
+++ b/docs/_guide/events.md
@@ -29,7 +29,7 @@ You can use lit-html `@event` bindings in your template to add event listeners t
 
 ```js
 render() {
-  return html`<button @click="${this.handleClick}">`;
+  return html`<button @click="${this._handleClick}">`;
 }
 ```
 
@@ -46,7 +46,7 @@ The component constructor is a good place to add event listeners on the host ele
 ```js
 constructor() {
   super();
-  this.addEventListener('focus', this.handleFocus);
+  this.addEventListener('focus', this._handleFocus);
 }
 ```
 
@@ -65,10 +65,10 @@ If your component adds an event listener to anything except itself or its childr
 ```js
 connectedCallback() {
   super.connectedCallback();
-  window.addEventListener('resize', this.handleResize);
+  window.addEventListener('resize', this._handleResize);
 }
 disconnectedCallback() {
-  window.removeEventListener('resize', this.handleResize);
+  window.removeEventListener('resize', this._handleResize);
   super.disconnectedCallback();
 }
 ```
@@ -116,14 +116,26 @@ this.boundResizeHandler = this.handleResize.bind(this);
 window.addEventListener('resize', this.boundResizeHandler);
 ```
 
+Or use an arrow function as a class field:
+
+```ts
+export class MyElement extends LitElement {
+  private _handleResize = () => { /* handle the event */ }
+
+  constructor() {
+    window.addEventListener('resize', this._handleResize);
+  }
+}
+```
+
 See the [documentation for `this` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this) for more information.
 
 ## Setting event listener options
 
-When you add an event listener imperatively, using `addEventListener`, you can specify various event listener options. For example, to use a capture phase event listener in plain JavaScript you'd do something like this:
+When you add an event listener imperatively, using `addEventListener`, you can specify various event listener options. For example, to use a passive event listener in plain JavaScript you'd do something like this:
 
 ```js
-someElement.addEventListener('click', this._handleClick, {capture: true});
+someElement.addEventListener('touchstart', this._handleTouchStart, {passive: true});
 ```
 
 The `eventOptions` decorator allows you to add event listener options to a listener that's added declaratively in your template.
@@ -132,19 +144,19 @@ The `eventOptions` decorator allows you to add event listener options to a liste
 import {LitElement, html, eventOptions} from 'lit-element';
 ...
 
-@eventOptions({capture: true})
-_handleClick_() { ... }
+@eventOptions({passive: true})
+private _handleTouchStart() { ... }
 
 render() { 
   return html`
-    <button @click=${this._handleClick}>Click me!</button>
+    <div @touchstart=${this._handleTouchStart}><div>
   `;
 }
 ```
 
 <div class="alert alert-info">
 
-**Using decorators.** Decorators are a proposed JavaScript feature, so you’ll need to use a compiler like Babel or the TypeScript compiler to use decorators. See Using decorators for details.
+**Using decorators.** Decorators are a proposed JavaScript feature, so you’ll need to use a compiler like Babel or TypeScript to use decorators. See [Using decorators](decorators) for details.
 
 </div>
 

--- a/docs/_guide/events.md
+++ b/docs/_guide/events.md
@@ -8,96 +8,156 @@ slug: events
 * ToC
 {:toc}
 
-## Overview
 
-### Where to add your event listeners
+## Where to add your event listeners
 
 You need to add event listeners in a method that is guaranteed to fire before the event occurs. However, for optimal loading performance, you should add your event listener as late as possible.  
 
-You can add event listeners:
+The most common ways to add an event listener:
 
-*   **Via your component's template.**
+* Declaratively, in  your component's template
+* In the component constructor, for listeners added on the component itself.
+* In the `connectedCallback`, for listeners that need to reference DOM outside the component (for example, `Window` or `Document`).
+* After first paint, if you're adding a lot of listeners and first paint performance is critical.
 
-    You can use lit-html `@event` bindings in your template inside the `render` function to add event listeners to your component. 
 
-    **Example**
+### Add declarative event listeners
 
-    ```js
-    render() {
-      return html`<button @click="${this.handleClick}">`;
-    }
-    ```
+You can use lit-html `@event` bindings in your template to add event listeners to your component. 
 
-*   **In the component constructor.**
+**Example**
 
-    If you need to listen for an event that might occur before your component has been added to DOM, you might need to add the event listener in your component's constructor. 
+```js
+render() {
+  return html`<button @click="${this.handleClick}">`;
+}
+```
 
-    **Example**
+Declarative event listeners are added when the template is rendered. This is usually the best way to add listeners to elements in your templated DOM.
 
-    ```js
-    constructor() {
-      super();
-      this.addEventListener('DOMContentLoaded', this.handleLoaded);
-    }
-    ```
+### Add event listeners in the constructor
 
-*   **In `firstUpdated`**.
+If you need to listen for an event that might occur before your component has been added to DOM, you might need to add the event listener in your component's constructor. 
 
-    `firstUpdated` is a LitElement lifecycle callback. `firstUpdated` fires after the first time your component has been updated and rendered. See [firstUpdated](/guide/lifecycle#firstupdated) in the Lifecycle documentation for more information.
+The component constructor is a good place to add event listeners on the host element itself.
 
-    If the event you're handling can't occur before your component has been updated and rendered for the first time, it's safe and efficient to add a listener for it in `firstUpdated`. 
+**Example**
 
-    **Example**
+```js
+constructor() {
+  super();
+  this.addEventListener('focus', this.handleFocus);
+}
+```
 
-    ```js
-    firstUpdated(changedProperties) {
-      this.addEventListener('click', this.handleClick);
-    }
-    ```
+### Add event listners in `connectedCallback`
 
-*   **In `connectedCallback`**. 
+`connectedCallback` is a lifecycle callback in the custom elements API. `connectedCallback` fires each time a custom element is appended into a document-connected element. See [the MDN documentation on using custom elements lifecycle callbacks](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks) for more information.
 
-    `connectedCallback` is a lifecycle callback in the custom elements API. `connectedCallback` fires each time a custom element is appended into a document-connected element. See [the MDN documentation on using custom elements lifecycle callbacks](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks) for more information.
+If your component adds an event listener to anything except itself or its children–for example, to `Window`, `Document`, or some element in the main DOM–you should add the listener in `connectedCallback` and remove it in `disconnectedCallback`.
 
-    If your component adds an event listener to anything except itself or its children–for example, to `Window`, `Document`, or some element in the main DOM–you should add the listener in `connectedCallback` and remove it in `disconnectedCallback`.
+*   Removing the event listener in `disconnectedCallback` ensures that any memory allocated by your component will be cleaned up when your component is destroyed or disconnected from the page. 
+
+*   Adding the event listener in `connectedCallback` (instead of, for example, the constructor or `firstUpdated`) ensures that your component will re-create its event listener if it is disconnected and subsequently reconnected to DOM.
+
+**Example**
+
+```js
+connectedCallback() {
+  super.connectedCallback();
+  window.addEventListener('resize', this.handleResize);
+}
+disconnectedCallback() {
+  window.removeEventListener('resize', this.handleResize);
+  super.disconnectedCallback();
+}
+```
+
+### Add event listeners after first paint
+
+Sometimes, you may want to defer adding an event listener until after first paint—for example, if you're adding a lot of listeners and first paint performance is critical.
+
+LitElement doesn't have a specific lifecycle callback called after first paint, but you can use this pattern with the `firstUpdated` lifecycle callback:
+
+```js
+async firstUpdated() {
+  // Give the browser a chance to paint
+  await new Promise((r) => setTimeout(r, 0));
+  this.addEventListener('click', this._handleClick);
+}
+```
+
+`firstUpdated` fires after the first time your component has been updated and called its `render` method, but **before the browser has had a chance to paint**. The `Promise`/`setTimeout` line yields to the browser
     
-    *   Removing the event listener in `disconnectedCallback` ensures that any memory allocated by your component will be cleaned up when your component is destroyed or disconnected from the page. 
+See [firstUpdated](/guide/lifecycle#firstupdated) in the Lifecycle documentation for more information.
 
-    *   Adding the event listener in `connectedCallback` (instead of, for example, the constructor or `firstRendered`) ensures that your component will re-create its event listener if it is disconnected and subsequently reconnected to DOM.
-    
-    **Example**
-    
-    ```js
-    connectedCallback() {
-      super.connectedCallback();
-      document.addEventListener('readystatechange', this.handleChange);
-    }
-    disconnectedCallback() {
-      document.removeEventListener('readystatechange', this.handleChange);
-      super.disconnectedCallback();
-    }
-    ```
 
-### Using `this` in event handlers
+## Using `this` in event listeners
 
-The default JavaScript context object (`this`) inside an event handler belonging to a LitElement-based component is the component itself. 
+Event listeners added using the declarative (`@event`) syntax in the template are automatically _bound_ to the component.
 
-Therefore, you can use `this` to refer to your element instance inside any event handler:
+Therefore, you can use `this` to refer to your component instance inside any declarative event handler:
 
 ```js
 class MyElement extends LitElement {
   render() {
-    return html`<button @click="${this.handleClick}">click</button>`;
+    return html`<button @click="${this._handleClick}">click</button>`;
   }
-  handleClick(e) {
+  _handleClick(e) {
     console.log(this.prop);
   }
 }
 ```
 
+When adding listeners imperatively with `addEventListener`, you'll need to bind the event listener yourself if you need a reference to the component instance. For example:
+
+```js
+this.boundResizeHandler = this.handleResize.bind(this);
+window.addEventListener('resize', this.boundResizeHandler);
+```
+
 See the [documentation for `this` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this) for more information.
 
-### Use cases
+## Setting event listener options
+
+When you add an event listener imperatively, using `addEventListener`, you can specify various event listener options. For example, to use a capture phase event listener in plain JavaScript you'd do something like this:
+
+```js
+someElement.addEventListener('click', this._handleClick, {capture: true});
+```
+
+The `eventOptions` decorator allows you to add event listener options to a listener that's added declaratively in your template.
+
+```js
+import {LitElement, html, eventOptions} from 'lit-element';
+...
+
+@eventOptions({capture: true})
+_handleClick_() { ... }
+
+render() { 
+  return html`
+    <button @click=${this._handleClick}>Click me!</button>
+  `;
+}
+```
+
+<div class="alert alert-info">
+
+**Using decorators.** Decorators are a proposed JavaScript feature, so you’ll need to use a compiler like Babel or the TypeScript compiler to use decorators. See Using decorators for details.
+
+</div>
+
+The object passed to `eventOptions` is used as the `options` parameter to `addEventListener`.
+
+
+
+More information:
+
+*   [EventTarget.addEventListener()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) on MDN for a description of the event listener options.
+
+
+## Use cases
 
 * [Fire a custom event from a LitElement-based component](#fire-custom-event).
 * [Handle a custom event fired by a LitElement-based component](#handle-custom-event).

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -157,6 +157,11 @@ html`<ul>
 </ul>`;
 ```
 
+<div class="alert alert-info">
+
+**repeat directive**. In most cases, `Array.map` is the most efficient way to create a repeating template. In some cases, you may want to consider lit-html's `repeat` directive. In particular, if the repeated elements are stateful, or very expensive to regenerate. For more information, see [Repeating templates with the repeat directive](https://lit-html.polymer-project.org/guide/writing-templates#repeating-templates-with-the-repeat-directive) in the lit-html docs.
+
+</div>
 #### Conditionals
 
 Render based on a Boolean condition:
@@ -375,21 +380,22 @@ You can compose LitElement templates from other LitElement templates. In the fol
 
 ```js
 class MyPage extends LitElement {
+  ...
   render() {
     return html`
-      ${this.headerTemplate}
-      ${this.articleTemplate}
+      ${this.headerTemplate(this.article.title)}
+      ${this.articleTemplate(this.article.text)}
       ${this.footerTemplate}
     `;
   }
-  get headerTemplate() {
-    return html`<header>header</header>`;
+  headerTemplate(title) {
+    return html`<header>${title}</header>`;
   }
-  get articleTemplate() {
-    return html`<article>article</article>`;
+  articleTemplate(text) {
+    return html`<article>${text}</article>`;
   }
   get footerTemplate() {
-    return html`<footer>footer</footer>`;
+    return html`<footer>Your footer here.</footer>`;
   }
 }
 ```

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -265,6 +265,12 @@ By default, if an element has a shadow tree, its children don't render at all.
 
 To render children, your template needs to include one or more [`<slot>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot), which act as placeholders for child nodes. 
 
+<div class="alert alert-info">
+
+**Finding slotted children.** If your component needs information about its slotted children, see [Accessing slotted children](#accessing-slotted-children).
+
+</div>
+
 #### Use the `slot` element
 
 To render an element's children, create a `<slot>` for them in the element's template. For example:
@@ -590,6 +596,11 @@ get closeButton() {
 
 LitElement supplies a set of decorators that provide a shorthand way of defining getters like this.
 
+More information:
+
+*   [Element.querySelector()](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelector) on MDN.
+*   [Element.querySelectorAll()](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelectorAll) on MDN.
+
 ### @query, @queryAll, and @queryAsync decorators
 
 The `@query`, `@queryAll`, and `@queryAsync` decorators all provide a convenient way to access nodes in the component's shadow root. 
@@ -659,11 +670,6 @@ The exclamation point (`!`) after `buttons` is TypeScript's [non-null assertion 
 Finally, `@queryAsync` works like `@query`, except that instead of returning a node directly, it returns a `Promise` that resolves to that node. External code can use this instead of waiting for the `updateComplete` promise. 
 
 This is useful, for example, if the node returned by `@queryAsync` can change as a result of another property change. 
-
-More information:
-
-*   [Element.querySelector()](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelector) on MDN.
-*   [Element.querySelectorAll()](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelectorAll) on MDN.
 
 ## Accessing slotted children
 

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -271,7 +271,7 @@ To render children, your template needs to include one or more [`<slot>` element
 
 </div>
 
-#### Use the `slot` element
+#### Use the slot element
 
 To render an element's children, create a `<slot>` for them in the element's template. For example:
 

--- a/docs/_guide/templates.md
+++ b/docs/_guide/templates.md
@@ -382,26 +382,27 @@ _index.html_
 
 ## Compose a template from other templates
 
-You can compose LitElement templates from other LitElement templates. In the following example, we compose a template for an element called `<my-page>` from smaller templates for the standard HTML elements `<header>`, `<article>`, and `<footer>`:
+You can compose LitElement templates from other LitElement templates. In the following example, we compose a template for an element called `<my-page>` from smaller templates for the page's header, footer, and main content:
 
 ```js
+  function headerTemplate(title) {
+    return html`<header>${title}</header>`;
+  }
+  function articleTemplate(text) {
+    return html`<article>${text}</article>`;
+  }
+  function footerTemplate() {
+    return html`<footer>Your footer here.</footer>`;
+  }
+
 class MyPage extends LitElement {
   ...
   render() {
     return html`
-      ${this.headerTemplate(this.article.title)}
-      ${this.articleTemplate(this.article.text)}
-      ${this.footerTemplate}
+      ${headerTemplate(this.article.title)}
+      ${articleTemplate(this.article.text)}
+      ${footerTemplate()}
     `;
-  }
-  headerTemplate(title) {
-    return html`<header>${title}</header>`;
-  }
-  articleTemplate(text) {
-    return html`<article>${text}</article>`;
-  }
-  get footerTemplate() {
-    return html`<footer>Your footer here.</footer>`;
   }
 }
 ```
@@ -582,14 +583,13 @@ html`${until(content, html`<span>Loading...</span>`)}`
 For a list of directives supplied with lit-html, see [Built-in directives](https://lit-html.polymer-project.org/guide/template-reference#built-in-directives) in the Template syntax reference.
 
 ## Accessing nodes in the shadow DOM
-
-Templated DOM is usually rendered into shadow DOM, so the nodes are not direct children of the component. Use `this.shadowRoot.querySelector()` or `this.shadowRoot.querySelectorAll()` to find nodes in the 
+The `render()` method result is usually rendered into shadow DOM, so the nodes are not direct children of the component. Use `this.shadowRoot.querySelector()` or `this.shadowRoot.querySelectorAll()` to find nodes in the 
 shadow DOM.
 
 You can query the templated DOM after its initial render (for example, in `firstUpdated`), or use a getter pattern, like this:
 
 ```js
-get closeButton() {
+get _closeButton() {
   return this.shadowRoot.querySelector('#close-button');
 }
 ```
@@ -607,16 +607,19 @@ The `@query`, `@queryAll`, and `@queryAsync` decorators all provide a convenient
 
 <div class="alert alert-info">
 
-**Using decorators.** Decorators are a proposed JavaScript feature, so you’ll need to use a compiler like Babel or the TypeScript compiler to use decorators. See [Using decorators](decorators) for details.
+**Using decorators.** Decorators are a proposed JavaScript feature, so you’ll need to use a compiler like Babel or TypeScript to use decorators. See [Using decorators](decorators) for details.
 
 </div>
 
 The `@query` decorator modifies a class property, turning it into a getter that returns a node from the render root.
 
 ```js
-class MyElement {
+import {LitElement, html} from 'lit-element';
+import {query} from 'lit-element/lib/decorators.js';
+
+class MyElement extends LitElement {
   @query('#first')
-  first;
+  _first;
 
   render() {
     return html`
@@ -645,9 +648,12 @@ The `@queryAll` decorator is identical to `query` except that it returns all mat
 
 
 ```js
-class MyElement {
+import {LitElement, html} from 'lit-element';
+import {queryAll} from 'lit-element/lib/decorators.js';
+
+class MyElement extends LitElement {
   @queryAll('div')
-  divs;
+  _divs;
 
   render() {
     return html`
@@ -660,14 +666,14 @@ class MyElement {
 
 Here, `divs` would return both `<div>` elements in the template. For TypeScript, the typing of a `@queryAll` property is `NodeListOf<HTMLElement>`. If you know exactly what kind of nodes you'll retrieve, the typing can be more specific:
 
-```
+```js
 @queryAll('button')
-buttons!: NodeListOf<HTMLButtonElement>
+_buttons!: NodeListOf<HTMLButtonElement>
 ```
 
 The exclamation point (`!`) after `buttons` is TypeScript's [non-null assertion operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#non-null-assertion-operator). It tells the compiler to treat `buttons` as always being defined, never `null` or `undefined`.
 
-Finally, `@queryAsync` works like `@query`, except that instead of returning a node directly, it returns a `Promise` that resolves to that node. External code can use this instead of waiting for the `updateComplete` promise. 
+Finally, `@queryAsync` works like `@query`, except that instead of returning a node directly, it returns a `Promise` that resolves to that node. Code can use this instead of waiting for the `updateComplete` promise. 
 
 This is useful, for example, if the node returned by `@queryAsync` can change as a result of another property change. 
 
@@ -678,7 +684,7 @@ To access children assigned to slots in your shadow root, you can use the standa
 For example, you can create a getter to access assigned nodes for a particular slot:
 
 ```js
-get slottedChildren() {
+get _slottedChildren() {
   const slot = this.shadowRoot.querySelector('slot');
   const childNodes = slot.assignedNodes({flatten: true});
   return Array.prototype.filter.call(childNodes, (node) => node.nodeType == Node.ELEMENT_NODE);
@@ -712,7 +718,7 @@ The `@queryAssignedNodes` decorator converts a class property into a getter that
 
 <div class="alert alert-info">
 
-**Using decorators.** Decorators are a proposed JavaScript feature, so you’ll need to use a compiler like Babel or the TypeScript compiler to use decorators. See [Using decorators](decorators) for details.
+**Using decorators.** Decorators are a proposed JavaScript feature, so you’ll need to use a compiler like Babel or TypeScript to use decorators. See [Using decorators](decorators) for details.
 
 </div>
 
@@ -720,11 +726,11 @@ The `@queryAssignedNodes` decorator converts a class property into a getter that
 // First argument is the slot name
 // Second argument is `true` to flatten the assigned nodes.
 @queryAssignedNodes('header', true)
-headerNodes;
+_headerNodes;
 
 // If the first argument is absent or an empty string, list nodes for the default slot.
 @queryAssignedNodes()
-defaultSlotNodes;
+_defaultSlotNodes;
 ```
 
 The first example above is equivalent to the following code:

--- a/docs/_includes/projects/docs/templates/compose/my-page.js
+++ b/docs/_includes/projects/docs/templates/compose/my-page.js
@@ -1,4 +1,14 @@
-import {LitElement, html} from 'lit-element';
+import { LitElement, html } from 'lit-element';
+
+function headerTemplate(title) {
+  return html`<header>${title}</header>`;
+}
+function articleTemplate(text) {
+  return html`<article>${text}</article>`;
+}
+function footerTemplate() {
+  return html`<footer>Your footer here.</footer>`;
+}
 
 class MyPage extends LitElement {
   static get properties() {
@@ -19,18 +29,10 @@ class MyPage extends LitElement {
 
   render() {
     return html`
-      ${this.headerTemplate(this.article.title)}
-      ${this.articleTemplate(this.article.text)} ${this.footerTemplate}
+      ${headerTemplate(this.article.title)}
+      ${articleTemplate(this.article.text)} 
+      ${footerTemplate()}
     `;
-  }
-  headerTemplate(title) {
-    return html`<header>${title}</header>`;
-  }
-  articleTemplate(text) {
-    return html`<article>${text}</article>`;
-  }
-  get footerTemplate() {
-    return html`<footer>Your footer here.</footer>`;
   }
 }
 customElements.define('my-page', MyPage);

--- a/docs/_includes/projects/docs/templates/compose/my-page.js
+++ b/docs/_includes/projects/docs/templates/compose/my-page.js
@@ -1,21 +1,36 @@
-import { LitElement, html } from 'lit-element';
+import {LitElement, html} from 'lit-element';
 
 class MyPage extends LitElement {
+  static get properties() {
+    return {
+      article: {
+        attribute: false,
+      },
+    };
+  }
+
+  constructor() {
+    super();
+    this.article = {
+      title: 'My Nifty Article',
+      text: 'Some witty text.',
+    };
+  }
+
   render() {
     return html`
-      ${this.headerTemplate}
-      ${this.articleTemplate}
-      ${this.footerTemplate}
+      ${this.headerTemplate(this.article.title)}
+      ${this.articleTemplate(this.article.text)} ${this.footerTemplate}
     `;
   }
-  get headerTemplate() {
-    return html`<header>header</header>`;
+  headerTemplate(title) {
+    return html`<header>${title}</header>`;
   }
-  get articleTemplate() {
-    return html`<article>article</article>`;
+  articleTemplate(text) {
+    return html`<article>${text}</article>`;
   }
   get footerTemplate() {
-    return html`<footer>footer</footer>`;
+    return html`<footer>Your footer here.</footer>`;
   }
 }
 customElements.define('my-page', MyPage);


### PR DESCRIPTION
Decorator docs part 2/2.

Follow-on to #999.
Fixes #886.

Staged as: https://decorator-docs-2-dot-polymer-lit-element.uk.r.appspot.com

(Note that this branch doesn't include the new decorators chapter--that's in #999--so the links to that chapter are broken in the staging link above.)
