### PR TITLE
Update copyright dates.

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -35,7 +35,7 @@
         </div>
         <div class="attribution">
           Brought to you by <a href="https://www.polymer-project.org">The Polymer Project</a>.<br>
-          Copyright 2018 The Polymer Project Authors. Code licensed under the
+          Copyright 2018-{{ "now" | date:"%Y" }} The Polymer Project Authors. Code licensed under the
           <a target="_blank" href="http://polymer.github.io/LICENSE.txt">BSD License</a>.
           Documentation licensed under CC BY 3.0.
         </div>


### PR DESCRIPTION
Fixes #1006 (at least, the part of it that's a fixable bug).

Sets the copyright date to 2018-_current year when the site was built_. Should be accurate unless we rebuild the docs site in new year without making any changes to it. I'm willing to live with that.

Staged: https://20200527t134714-dot-polymer-lit-element.uk.r.appspot.com
