### PR TITLE
Update API docs for 2.4.0.

### DIFF
--- a/docs/api/classes/_lib_updating_element_.updatingelement.html
+++ b/docs/api/classes/_lib_updating_element_.updatingelement.html
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L511">src/lib/updating-element.ts:511</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L511">src/lib/updating-element.ts:511</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="_lib_updating_element_.updatingelement.html" class="tsd-signature-type">UpdatingElement</a></h4>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">[finalized]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L235">src/lib/updating-element.ts:235</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L235">src/lib/updating-element.ts:235</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">properties<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_lit_element_.propertydeclarations.html" class="tsd-signature-type">PropertyDeclarations</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L247">src/lib/updating-element.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L247">src/lib/updating-element.ts:247</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -243,7 +243,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L738">src/lib/updating-element.ts:738</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L738">src/lib/updating-element.ts:738</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -260,7 +260,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L815">src/lib/updating-element.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L815">src/lib/updating-element.ts:815</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -292,7 +292,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L253">src/lib/updating-element.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L253">src/lib/updating-element.ts:253</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L835">src/lib/updating-element.ts:835</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L835">src/lib/updating-element.ts:835</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -354,7 +354,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L596">src/lib/updating-element.ts:596</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L596">src/lib/updating-element.ts:596</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L572">src/lib/updating-element.ts:572</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L572">src/lib/updating-element.ts:572</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -405,7 +405,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L590">src/lib/updating-element.ts:590</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L590">src/lib/updating-element.ts:590</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -429,7 +429,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L578">src/lib/updating-element.ts:578</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L578">src/lib/updating-element.ts:578</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -446,7 +446,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L891">src/lib/updating-element.ts:891</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L891">src/lib/updating-element.ts:891</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -480,7 +480,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L522">src/lib/updating-element.ts:522</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L522">src/lib/updating-element.ts:522</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -503,7 +503,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L758">src/lib/updating-element.ts:758</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L758">src/lib/updating-element.ts:758</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -533,7 +533,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L706">src/lib/updating-element.ts:706</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L706">src/lib/updating-element.ts:706</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -577,7 +577,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L660">src/lib/updating-element.ts:660</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L660">src/lib/updating-element.ts:660</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -613,7 +613,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L846">src/lib/updating-element.ts:846</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L846">src/lib/updating-element.ts:846</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -646,7 +646,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L858">src/lib/updating-element.ts:858</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L858">src/lib/updating-element.ts:858</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -680,7 +680,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L879">src/lib/updating-element.ts:879</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L879">src/lib/updating-element.ts:879</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -714,7 +714,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L313">src/lib/updating-element.ts:313</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L313">src/lib/updating-element.ts:313</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -764,7 +764,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L401">src/lib/updating-element.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L401">src/lib/updating-element.ts:401</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -791,7 +791,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L360">src/lib/updating-element.ts:360</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L360">src/lib/updating-element.ts:360</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -850,7 +850,7 @@
 										<li class="tsd-description">
 											<aside class="tsd-sources">
 												<ul>
-													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L364">src/lib/updating-element.ts:364</a></li>
+													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L364">src/lib/updating-element.ts:364</a></li>
 												</ul>
 											</aside>
 											<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>
@@ -866,7 +866,7 @@
 										<li class="tsd-description">
 											<aside class="tsd-sources">
 												<ul>
-													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L367">src/lib/updating-element.ts:367</a></li>
+													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L367">src/lib/updating-element.ts:367</a></li>
 												</ul>
 											</aside>
 											<h4 class="tsd-parameters-title">Parameters</h4>
@@ -896,7 +896,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L391">src/lib/updating-element.ts:391</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L391">src/lib/updating-element.ts:391</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/classes/_lit_element_.cssresult.html
+++ b/docs/api/classes/_lit_element_.cssresult.html
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/css-tag.ts#L25">src/lib/css-tag.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/css-tag.ts#L25">src/lib/css-tag.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">_style<wbr>Sheet<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">CSSStyleSheet</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/css-tag.ts#L23">src/lib/css-tag.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/css-tag.ts#L23">src/lib/css-tag.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">css<wbr>Text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/css-tag.ts#L25">src/lib/css-tag.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/css-tag.ts#L25">src/lib/css-tag.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/css-tag.ts#L38">src/lib/css-tag.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/css-tag.ts#L38">src/lib/css-tag.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">CSSStyleSheet</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/css-tag.ts#L52">src/lib/css-tag.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/css-tag.ts#L52">src/lib/css-tag.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>

--- a/docs/api/classes/_lit_element_.litelement.html
+++ b/docs/api/classes/_lit_element_.litelement.html
@@ -196,7 +196,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L511">src/lib/updating-element.ts:511</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L511">src/lib/updating-element.ts:511</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="_lit_element_.litelement.html" class="tsd-signature-type">LitElement</a></h4>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">render<wbr>Root<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Element</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">DocumentFragment</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L210">src/lit-element.ts:210</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L210">src/lit-element.ts:210</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#_finalized_">[finalized]</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L235">src/lib/updating-element.ts:235</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L235">src/lib/updating-element.ts:235</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 					<div class="tsd-signature tsd-kind-icon">finalized<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L106">src/lit-element.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L106">src/lit-element.ts:106</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#properties">properties</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L247">src/lib/updating-element.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L247">src/lib/updating-element.ts:247</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -279,7 +279,7 @@
 					<div class="tsd-signature tsd-kind-icon">render<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>result<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">unknown</span>, container<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Element</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">DocumentFragment</span>, options<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ShadyRenderOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> = render</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L125">src/lit-element.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L125">src/lit-element.ts:125</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@
 					<div class="tsd-signature tsd-kind-icon">styles<span class="tsd-signature-symbol">:</span> <a href="../modules/_lit_element_.html#cssresultornative" class="tsd-signature-type">CSSResultOrNative</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_lit_element_.cssresultarray.html" class="tsd-signature-type">CSSResultArray</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L133">src/lit-element.ts:133</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L133">src/lit-element.ts:133</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -358,7 +358,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#hasupdated">hasUpdated</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L738">src/lib/updating-element.ts:738</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L738">src/lib/updating-element.ts:738</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -376,7 +376,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#updatecomplete">updateComplete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L815">src/lib/updating-element.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L815">src/lib/updating-element.ts:815</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -409,7 +409,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#observedattributes">observedAttributes</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L253">src/lib/updating-element.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L253">src/lib/updating-element.ts:253</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -439,7 +439,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#_getupdatecomplete">_getUpdateComplete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L835">src/lib/updating-element.ts:835</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L835">src/lib/updating-element.ts:835</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -472,7 +472,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L251">src/lit-element.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L251">src/lit-element.ts:251</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -501,7 +501,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#attributechangedcallback">attributeChangedCallback</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L596">src/lib/updating-element.ts:596</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L596">src/lib/updating-element.ts:596</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -536,7 +536,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="_lit_element_.updatingelement.html">UpdatingElement</a>.<a href="_lit_element_.updatingelement.html#connectedcallback">connectedCallback</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L274">src/lit-element.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L274">src/lit-element.ts:274</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -553,7 +553,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L238">src/lit-element.ts:238</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L238">src/lit-element.ts:238</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -580,7 +580,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#disconnectedcallback">disconnectedCallback</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L590">src/lib/updating-element.ts:590</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L590">src/lib/updating-element.ts:590</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -605,7 +605,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#enableupdating">enableUpdating</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L578">src/lib/updating-element.ts:578</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L578">src/lib/updating-element.ts:578</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -623,7 +623,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#firstupdated">firstUpdated</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L891">src/lib/updating-element.ts:891</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L891">src/lib/updating-element.ts:891</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -658,7 +658,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="_lit_element_.updatingelement.html">UpdatingElement</a>.<a href="_lit_element_.updatingelement.html#initialize">initialize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L217">src/lit-element.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L217">src/lit-element.ts:217</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -683,7 +683,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#performupdate">performUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L758">src/lib/updating-element.ts:758</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L758">src/lib/updating-element.ts:758</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -713,7 +713,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L322">src/lit-element.ts:322</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L322">src/lit-element.ts:322</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -739,7 +739,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#requestupdate">requestUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L706">src/lib/updating-element.ts:706</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L706">src/lib/updating-element.ts:706</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -784,7 +784,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#requestupdateinternal">requestUpdateInternal</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L660">src/lib/updating-element.ts:660</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L660">src/lib/updating-element.ts:660</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -821,7 +821,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#shouldupdate">shouldUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L846">src/lib/updating-element.ts:846</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L846">src/lib/updating-element.ts:846</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -855,7 +855,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="_lit_element_.updatingelement.html">UpdatingElement</a>.<a href="_lit_element_.updatingelement.html#update">update</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L289">src/lit-element.ts:289</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L289">src/lit-element.ts:289</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -886,7 +886,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#updated">updated</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L879">src/lib/updating-element.ts:879</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L879">src/lib/updating-element.ts:879</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -921,7 +921,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#createproperty">createProperty</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L313">src/lib/updating-element.ts:313</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L313">src/lib/updating-element.ts:313</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -972,7 +972,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#finalize">finalize</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L401">src/lib/updating-element.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L401">src/lib/updating-element.ts:401</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1000,7 +1000,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#getpropertydescriptor">getPropertyDescriptor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L360">src/lib/updating-element.ts:360</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L360">src/lib/updating-element.ts:360</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1059,7 +1059,7 @@
 										<li class="tsd-description">
 											<aside class="tsd-sources">
 												<ul>
-													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L364">src/lib/updating-element.ts:364</a></li>
+													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L364">src/lib/updating-element.ts:364</a></li>
 												</ul>
 											</aside>
 											<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>
@@ -1075,7 +1075,7 @@
 										<li class="tsd-description">
 											<aside class="tsd-sources">
 												<ul>
-													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L367">src/lib/updating-element.ts:367</a></li>
+													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L367">src/lib/updating-element.ts:367</a></li>
 												</ul>
 											</aside>
 											<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1106,7 +1106,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_lit_element_.litelement.html">LitElement</a>.<a href="_lit_element_.litelement.html#getpropertyoptions">getPropertyOptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L391">src/lib/updating-element.ts:391</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L391">src/lib/updating-element.ts:391</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1145,7 +1145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L143">src/lit-element.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L143">src/lit-element.ts:143</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/classes/_lit_element_.updatingelement.html
+++ b/docs/api/classes/_lit_element_.updatingelement.html
@@ -194,7 +194,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L511">src/lib/updating-element.ts:511</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L511">src/lib/updating-element.ts:511</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="_lit_element_.updatingelement.html" class="tsd-signature-type">UpdatingElement</a></h4>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">[finalized]<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L235">src/lib/updating-element.ts:235</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L235">src/lib/updating-element.ts:235</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">properties<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_lit_element_.propertydeclarations.html" class="tsd-signature-type">PropertyDeclarations</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L247">src/lib/updating-element.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L247">src/lib/updating-element.ts:247</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -248,7 +248,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L738">src/lib/updating-element.ts:738</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L738">src/lib/updating-element.ts:738</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L815">src/lib/updating-element.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L815">src/lib/updating-element.ts:815</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L253">src/lib/updating-element.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L253">src/lib/updating-element.ts:253</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L835">src/lib/updating-element.ts:835</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L835">src/lib/updating-element.ts:835</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L596">src/lib/updating-element.ts:596</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L596">src/lib/updating-element.ts:596</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -393,7 +393,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L572">src/lib/updating-element.ts:572</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L572">src/lib/updating-element.ts:572</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -410,7 +410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L590">src/lib/updating-element.ts:590</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L590">src/lib/updating-element.ts:590</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L578">src/lib/updating-element.ts:578</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L578">src/lib/updating-element.ts:578</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -451,7 +451,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L891">src/lib/updating-element.ts:891</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L891">src/lib/updating-element.ts:891</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -485,7 +485,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L522">src/lib/updating-element.ts:522</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L522">src/lib/updating-element.ts:522</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -508,7 +508,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L758">src/lib/updating-element.ts:758</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L758">src/lib/updating-element.ts:758</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -538,7 +538,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L706">src/lib/updating-element.ts:706</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L706">src/lib/updating-element.ts:706</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -582,7 +582,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L660">src/lib/updating-element.ts:660</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L660">src/lib/updating-element.ts:660</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -618,7 +618,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L846">src/lib/updating-element.ts:846</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L846">src/lib/updating-element.ts:846</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -651,7 +651,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L858">src/lib/updating-element.ts:858</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L858">src/lib/updating-element.ts:858</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -685,7 +685,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L879">src/lib/updating-element.ts:879</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L879">src/lib/updating-element.ts:879</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -719,7 +719,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L313">src/lib/updating-element.ts:313</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L313">src/lib/updating-element.ts:313</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -769,7 +769,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L401">src/lib/updating-element.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L401">src/lib/updating-element.ts:401</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -796,7 +796,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L360">src/lib/updating-element.ts:360</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L360">src/lib/updating-element.ts:360</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -855,7 +855,7 @@
 										<li class="tsd-description">
 											<aside class="tsd-sources">
 												<ul>
-													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L364">src/lib/updating-element.ts:364</a></li>
+													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L364">src/lib/updating-element.ts:364</a></li>
 												</ul>
 											</aside>
 											<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>
@@ -871,7 +871,7 @@
 										<li class="tsd-description">
 											<aside class="tsd-sources">
 												<ul>
-													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L367">src/lib/updating-element.ts:367</a></li>
+													<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L367">src/lib/updating-element.ts:367</a></li>
 												</ul>
 											</aside>
 											<h4 class="tsd-parameters-title">Parameters</h4>
@@ -901,7 +901,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L391">src/lib/updating-element.ts:391</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L391">src/lib/updating-element.ts:391</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/interfaces/_lib_updating_element_.complexattributeconverter.html
+++ b/docs/api/interfaces/_lib_updating_element_.complexattributeconverter.html
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L47">src/lib/updating-element.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L47">src/lib/updating-element.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L56">src/lib/updating-element.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L56">src/lib/updating-element.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/interfaces/_lib_updating_element_.haschanged.html
+++ b/docs/api/interfaces/_lib_updating_element_.haschanged.html
@@ -118,7 +118,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L175">src/lib/updating-element.ts:175</a></li>
+								<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L175">src/lib/updating-element.ts:175</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/interfaces/_lib_updating_element_.propertydeclaration.html
+++ b/docs/api/interfaces/_lib_updating_element_.propertydeclaration.html
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">attribute<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L74">src/lib/updating-element.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L74">src/lib/updating-element.ts:74</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">converter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AttributeConverter</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Type</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">TypeHint</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L95">src/lib/updating-element.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L95">src/lib/updating-element.ts:95</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">no<wbr>Accessor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L121">src/lib/updating-element.ts:121</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L121">src/lib/updating-element.ts:121</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">reflect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L104">src/lib/updating-element.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L104">src/lib/updating-element.ts:104</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="" class="tsd-signature-type">TypeHint</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L81">src/lib/updating-element.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L81">src/lib/updating-element.ts:81</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L111">src/lib/updating-element.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L111">src/lib/updating-element.ts:111</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/interfaces/_lit_element_.complexattributeconverter.html
+++ b/docs/api/interfaces/_lit_element_.complexattributeconverter.html
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L47">src/lib/updating-element.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L47">src/lib/updating-element.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L56">src/lib/updating-element.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L56">src/lib/updating-element.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/interfaces/_lit_element_.haschanged.html
+++ b/docs/api/interfaces/_lit_element_.haschanged.html
@@ -118,7 +118,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L175">src/lib/updating-element.ts:175</a></li>
+								<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L175">src/lib/updating-element.ts:175</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/interfaces/_lit_element_.internalpropertydeclaration.html
+++ b/docs/api/interfaces/_lit_element_.internalpropertydeclaration.html
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L175">src/lib/decorators.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L175">src/lib/decorators.ts:175</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/interfaces/_lit_element_.propertydeclaration.html
+++ b/docs/api/interfaces/_lit_element_.propertydeclaration.html
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">attribute<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L74">src/lib/updating-element.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L74">src/lib/updating-element.ts:74</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">converter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AttributeConverter</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Type</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">TypeHint</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L95">src/lib/updating-element.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L95">src/lib/updating-element.ts:95</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">no<wbr>Accessor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L121">src/lib/updating-element.ts:121</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L121">src/lib/updating-element.ts:121</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">reflect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L104">src/lib/updating-element.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L104">src/lib/updating-element.ts:104</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="" class="tsd-signature-type">TypeHint</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L81">src/lib/updating-element.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L81">src/lib/updating-element.ts:81</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L111">src/lib/updating-element.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L111">src/lib/updating-element.ts:111</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/modules/_lib_updating_element_.html
+++ b/docs/api/modules/_lib_updating_element_.html
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">Property<wbr>Values&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><span class="tsd-signature-type">PropertyKey</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">never</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L142">src/lib/updating-element.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L142">src/lib/updating-element.ts:142</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -183,7 +183,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L183">src/lib/updating-element.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L183">src/lib/updating-element.ts:183</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Converter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L145">src/lib/updating-element.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L145">src/lib/updating-element.ts:145</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-object-literal">
@@ -227,7 +227,7 @@
 							<li class="tsd-description">
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L160">src/lib/updating-element.ts:160</a></li>
+										<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L160">src/lib/updating-element.ts:160</a></li>
 									</ul>
 								</aside>
 								<h4 class="tsd-parameters-title">Parameters</h4>
@@ -253,7 +253,7 @@
 							<li class="tsd-description">
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L147">src/lib/updating-element.ts:147</a></li>
+										<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L147">src/lib/updating-element.ts:147</a></li>
 									</ul>
 								</aside>
 								<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_lit_element_.html
+++ b/docs/api/modules/_lit_element_.html
@@ -213,7 +213,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 					<div class="tsd-signature tsd-kind-icon">CSSResult<wbr>OrNative<span class="tsd-signature-symbol">:</span> <a href="../classes/_lit_element_.cssresult.html" class="tsd-signature-type">CSSResult</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CSSStyleSheet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lit-element.ts#L79">src/lit-element.ts:79</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lit-element.ts#L79">src/lit-element.ts:79</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -223,7 +223,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 					<div class="tsd-signature tsd-kind-icon">Constructor&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>constructor<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L26">src/lib/decorators.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L26">src/lib/decorators.ts:26</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -244,7 +244,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 									<li class="tsd-description">
 										<aside class="tsd-sources">
 											<ul>
-												<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L26">src/lib/decorators.ts:26</a></li>
+												<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L26">src/lib/decorators.ts:26</a></li>
 											</ul>
 										</aside>
 										<h4 class="tsd-parameters-title">Parameters</h4>
@@ -266,7 +266,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 					<div class="tsd-signature tsd-kind-icon">Property<wbr>Values&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><span class="tsd-signature-type">PropertyKey</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">never</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L142">src/lib/updating-element.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L142">src/lib/updating-element.ts:142</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -331,7 +331,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 					<div class="tsd-signature tsd-kind-icon">supports<wbr>Adopting<wbr>Style<wbr>Sheets<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = (window.ShadowRoot) &amp;&amp;(window.ShadyCSS &#x3D;&#x3D;&#x3D; undefined || window.ShadyCSS.nativeShadow) &amp;&amp;(&#x27;adoptedStyleSheets&#x27; in Document.prototype) &amp;&amp;(&#x27;replace&#x27; in CSSStyleSheet.prototype)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/css-tag.ts#L15">src/lib/css-tag.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/css-tag.ts#L15">src/lib/css-tag.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -393,7 +393,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L88">src/lib/decorators.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L88">src/lib/decorators.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -432,7 +432,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L404">src/lib/decorators.ts:404</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L406">src/lib/decorators.ts:406</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -487,7 +487,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L187">src/lib/decorators.ts:187</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L187">src/lib/decorators.ts:187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -519,7 +519,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L161">src/lib/decorators.ts:161</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L161">src/lib/decorators.ts:161</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -561,7 +561,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L218">src/lib/decorators.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L218">src/lib/decorators.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -616,7 +616,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L326">src/lib/decorators.ts:326</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L328">src/lib/decorators.ts:328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -665,7 +665,7 @@ customElements.define(<span class="hljs-string">'my-element'</span>, MyElement);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L446">src/lib/decorators.ts:446</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L454">src/lib/decorators.ts:454</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -727,7 +727,7 @@ render() {
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/decorators.ts#L283">src/lib/decorators.ts:283</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/decorators.ts#L285">src/lib/decorators.ts:285</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -787,7 +787,7 @@ render() {
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/css-tag.ts#L87">src/lib/css-tag.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/css-tag.ts#L87">src/lib/css-tag.ts:87</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -821,7 +821,7 @@ render() {
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L183">src/lib/updating-element.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L183">src/lib/updating-element.ts:183</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -853,7 +853,7 @@ render() {
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/css-tag.ts#L64">src/lib/css-tag.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/css-tag.ts#L64">src/lib/css-tag.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -883,7 +883,7 @@ render() {
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Converter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L145">src/lib/updating-element.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L145">src/lib/updating-element.ts:145</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-function tsd-parent-kind-object-literal">
@@ -896,7 +896,7 @@ render() {
 							<li class="tsd-description">
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L160">src/lib/updating-element.ts:160</a></li>
+										<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L160">src/lib/updating-element.ts:160</a></li>
 									</ul>
 								</aside>
 								<h4 class="tsd-parameters-title">Parameters</h4>
@@ -922,7 +922,7 @@ render() {
 							<li class="tsd-description">
 								<aside class="tsd-sources">
 									<ul>
-										<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/683906a/src/lib/updating-element.ts#L147">src/lib/updating-element.ts:147</a></li>
+										<li>Defined in <a href="https://github.com/Polymer/lit-element/blob/a21abcb/src/lib/updating-element.ts#L147">src/lib/updating-element.ts:147</a></li>
 									</ul>
 								</aside>
 								<h4 class="tsd-parameters-title">Parameters</h4>


### PR DESCRIPTION
Regenerated API docs at HEAD. As far as I can see, this just updates the source code links. 