### PR TITLE
Add type assertion to JSON.parse().

### DIFF
--- a/src/lib/updating-element.ts
+++ b/src/lib/updating-element.ts
@@ -165,7 +165,8 @@ export const defaultConverter: ComplexAttributeConverter = {
         return value === null ? null : Number(value);
       case Object:
       case Array:
-        return JSON.parse(value!);
+        // Type assert to adhere to Bazel's "must type assert JSON parse" rule.
+        return JSON.parse(value!) as unknown;
     }
     return value;
   }


### PR DESCRIPTION
This makes this repo compliant with Bazel's TypeScript rules: https://github.com/bazelbuild/rules_typescript/blob/master/internal/tsetse/rules/must_type_assert_json_parse_rule.ts