### PR TITLE
Fix @query decorator cache for modern mode

### DIFF
--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -227,15 +227,16 @@ export function query(selector: string, cache?: boolean) {
       configurable: true,
     };
     if (cache) {
-      const key = typeof name === 'symbol' ? Symbol() : `__${name}`;
+      const key = name || (protoOrDescriptor as ClassElement).key;
+      const cacheKey = typeof key === 'symbol' ? Symbol() : `__${key}`;
       descriptor.get = function(this: LitElement) {
         if ((this as unknown as
-             {[key: string]: Element | null})[key as string] === undefined) {
-          ((this as unknown as {[key: string]: Element | null})[key as string] =
+             {[key: string]: Element | null})[cacheKey as string] === undefined) {
+          ((this as unknown as {[key: string]: Element | null})[cacheKey as string] =
                this.renderRoot.querySelector(selector));
         }
         return (
-            this as unknown as {[key: string]: Element | null})[key as string];
+            this as unknown as {[key: string]: Element | null})[cacheKey as string];
       };
     }
     return (name !== undefined) ?


### PR DESCRIPTION
Right now the `name` is used for the key for the cache of the element.

But `name` is `undefined` for modern decorators, meaning all elements will be saved as `__undefined` and multiple `@query` decorators with `cache` all return the same element of the first one used.

This uses the `protoOrDescriptor.key` when `name` is `undefined`.