### PR TITLE
chore: include package exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./lit-element.js",
+    "./lib/*": "./lib/*.js",
+    "./src/*": "./src/*.js",
+    "./ts3.4/*": "./ts3.4/*.ts"
   }
 }


### PR DESCRIPTION
# What it does

- Define [Package entry points](https://nodejs.org/api/packages.html#packages_package_entry_points)

## Why

It will help bundlers to tree shaking the bundle and services like skypack.dev (@FredKSchott) can inspect all entry points to avoid serving some files as raw or helps to generate URLs correctly.