### PR TITLE
Add @nocollapse to shadowRootOptions

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -132,6 +132,7 @@ export class LitElement extends UpdatingElement {
    */
   static styles?: CSSResultOrNative|CSSResultArray;
 
+  /** @nocollapse */
   static shadowRootOptions: ShadowRootInit = { mode: "open" };
 
   private static _styles: Array<CSSResultOrNative|CSSResult>|undefined;


### PR DESCRIPTION
Static fields must be annotated with `@nocollapse` to get proper semantics -.-