### PR TITLE
lit-next forward-compat: Backport `CSSResultGroup` type.

### DIFF
--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -133,7 +133,7 @@ export class LitElement extends UpdatingElement {
    * Array of styles to apply to the element. The styles should be defined
    * using the [[`css`]] tag function or via constructible stylesheets.
    */
-  static styles?: CSSResultOrNative|CSSResultArray;
+  static styles?: CSSResultGroup;
 
   /** @nocollapse */
   static shadowRootOptions: ShadowRootInit = {mode: 'open'};
@@ -146,7 +146,7 @@ export class LitElement extends UpdatingElement {
    *
    * @nocollapse
    */
-  static getStyles(): CSSResultOrNative|CSSResultArray|undefined {
+  static getStyles(): CSSResultGroup|undefined {
     return this.styles;
   }
 

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -82,6 +82,8 @@ export type CSSResultOrNative = CSSResult|CSSStyleSheet;
 export interface CSSResultArray extends
     Array<CSSResultOrNative|CSSResultArray> {}
 
+export type CSSResultGroup = CSSResultOrNative | CSSResultArray;
+
 /**
  * Sentinal value used to avoid calling lit-html's render function when
  * subclasses do not implement `render`

--- a/src/lit-element.ts
+++ b/src/lit-element.ts
@@ -82,7 +82,7 @@ export type CSSResultOrNative = CSSResult|CSSStyleSheet;
 export interface CSSResultArray extends
     Array<CSSResultOrNative|CSSResultArray> {}
 
-export type CSSResultGroup = CSSResultOrNative | CSSResultArray;
+export type CSSResultGroup = CSSResultOrNative|CSSResultArray;
 
 /**
  * Sentinal value used to avoid calling lit-html's render function when


### PR DESCRIPTION
This PR backports the `CSSResultGroup` type from `ReactiveElement`:
https://github.com/Polymer/lit-html/blob/664fbfb097712709de19a2a26d3caf89239ac723/packages/reactive-element/src/css-tag.ts#L22