### PR TITLE
Do not redefine class in `customElement` decorator if already defined

### DIFF
--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -48,6 +48,10 @@ interface ClassElement {
 
 const legacyCustomElement =
     (tagName: string, clazz: Constructor<HTMLElement>) => {
+      // Do not define if already registered
+      const isDefined = Boolean(window.customElements.get(tagName));
+      // tslint:disable-next-line:no-any
+      if (isDefined) return clazz as any;
       window.customElements.define(tagName, clazz);
       // Cast as any because TS doesn't recognize the return type as being a
       // subtype of the decorated class when clazz is typed as


### PR DESCRIPTION
<!-- Instructions: https://github.com/lit/lit-element/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
Fixes [#3794](https://github.com/lit/lit/issues/3794)

Change `customElement` decorator to not define a custom element if it is already in the registry.

This eliminates DOM exceptions when multiple scripts are accidentally imported.


